### PR TITLE
feat: support LDAP Groups API

### DIFF
--- a/client/endpoint/endpoint.go
+++ b/client/endpoint/endpoint.go
@@ -25,6 +25,8 @@ type Endpoints struct {
 	streams                 *url.URL
 	users                   *url.URL
 	ldapSetting             string
+	ldapGroups              string
+	ldapGroupRoleMapping    string
 }
 
 // NewEndpoints returns a new Endpoints.
@@ -84,6 +86,14 @@ func NewEndpoints(endpoint string) (*Endpoints, error) {
 	if err != nil {
 		return nil, err
 	}
+	ldapGroups, err := urlJoin(ep, "system/ldap/groups")
+	if err != nil {
+		return nil, err
+	}
+	ldapGroupRoleMapping, err := urlJoin(ep, "system/ldap/settings/groups")
+	if err != nil {
+		return nil, err
+	}
 	users, err := urlJoin(ep, "users")
 	if err != nil {
 		return nil, err
@@ -102,5 +112,7 @@ func NewEndpoints(endpoint string) (*Endpoints, error) {
 		streams:                 streams,
 		users:                   users,
 		ldapSetting:             ldapSetting.String(),
+		ldapGroups:              ldapGroups.String(),
+		ldapGroupRoleMapping:    ldapGroupRoleMapping.String(),
 	}, nil
 }

--- a/client/endpoint/ldap_setting.go
+++ b/client/endpoint/ldap_setting.go
@@ -4,3 +4,15 @@ package endpoint
 func (ep *Endpoints) LDAPSetting() string {
 	return ep.ldapSetting
 }
+
+// LDAPGroups returns the LDAP Setting API's endpoint url.
+func (ep *Endpoints) LDAPGroups() string {
+	// /system/ldap/groups
+	return ep.ldapGroups
+}
+
+// LDAPGroupRoleMapping returns the LDAP Group and role mapping API's endpoint url.
+func (ep *Endpoints) LDAPGroupRoleMapping() string {
+	// /system/ldap/settings/groups
+	return ep.ldapGroupRoleMapping
+}

--- a/client/ldap_group.go
+++ b/client/ldap_group.go
@@ -1,0 +1,45 @@
+package client
+
+import (
+	"context"
+)
+
+// GetLDAPGroups returns the available LDAP groups.
+func (client *Client) GetLDAPGroups() ([]string, *ErrorInfo, error) {
+	return client.GetLDAPGroupsContext(context.Background())
+}
+
+// GetLDAPGroupsContext returns the available LDAP groups with a context.
+func (client *Client) GetLDAPGroupsContext(ctx context.Context) ([]string, *ErrorInfo, error) {
+	// GET /system/ldap/groups Get the available LDAP groups
+	groups := []string{}
+	ei, err := client.callGet(
+		ctx, client.Endpoints().LDAPGroups(), nil, &groups)
+	return groups, ei, err
+}
+
+// GetLDAPGroupRoleMapping returns the LDAP group and role mapping.
+func (client *Client) GetLDAPGroupRoleMapping() (map[string]string, *ErrorInfo, error) {
+	return client.GetLDAPGroupRoleMappingContext(context.Background())
+}
+
+// GetLDAPGroupRoleMappingContext returns the LDAP group and role mapping with a context.
+func (client *Client) GetLDAPGroupRoleMappingContext(ctx context.Context) (map[string]string, *ErrorInfo, error) {
+	// GET /system/ldap/settings/groups Get the LDAP group to Graylog role mapping
+	m := map[string]string{}
+	ei, err := client.callGet(
+		ctx, client.Endpoints().LDAPGroupRoleMapping(), nil, &m)
+	return m, ei, err
+}
+
+// UpdateLDAPGroupRoleMapping updates the LDAP group and role mapping.
+func (client *Client) UpdateLDAPGroupRoleMapping(mapping map[string]string) (*ErrorInfo, error) {
+	return client.UpdateLDAPGroupRoleMappingContext(context.Background(), mapping)
+}
+
+// UpdateLDAPGroupRoleMappingContext returns the LDAP group and role mapping with a context.
+func (client *Client) UpdateLDAPGroupRoleMappingContext(ctx context.Context, mapping map[string]string) (*ErrorInfo, error) {
+	// PUT /system/ldap/settings/groups Update the LDAP group to Graylog role mapping
+	return client.callPut(
+		ctx, client.Endpoints().LDAPGroupRoleMapping(), mapping, nil)
+}

--- a/client/ldap_group_test.go
+++ b/client/ldap_group_test.go
@@ -1,0 +1,109 @@
+package client_test
+
+import (
+	"os"
+	"testing"
+
+	"gopkg.in/h2non/gock.v1"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/suzuki-shunsuke/go-graylog/client"
+)
+
+func TestGetLDAPGroups(t *testing.T) {
+	authName := os.Getenv("GRAYLOG_AUTH_NAME")
+	authPass := os.Getenv("GRAYLOG_AUTH_PASSWORD")
+	endpoint := os.Getenv("GRAYLOG_WEB_ENDPOINT_URI")
+
+	if endpoint == "" {
+		defer gock.Off()
+		endpoint = "http://example.com/api"
+		client, err := client.NewClient(endpoint, authName, authPass)
+		assert.Nil(t, err)
+		data := []struct {
+			statusCode int
+			resp       string
+			groups     []string
+			checkErr   func(assert.TestingT, interface{}, ...interface{}) bool
+		}{{
+			statusCode: 200,
+			resp:       `["foo"]`,
+			groups:     []string{"foo"},
+			checkErr:   assert.Nil,
+		}}
+		for _, d := range data {
+			gock.New("http://example.com").
+				Get("/api/system/ldap/groups").
+				MatchType("json").Reply(d.statusCode).BodyString(d.resp)
+			m, _, err := client.GetLDAPGroups()
+			if err != nil {
+				assert.Equal(t, d.groups, m)
+			}
+			d.checkErr(t, err)
+		}
+	}
+}
+
+func TestGetLDAPGroupRoleMapping(t *testing.T) {
+	authName := os.Getenv("GRAYLOG_AUTH_NAME")
+	authPass := os.Getenv("GRAYLOG_AUTH_PASSWORD")
+	endpoint := os.Getenv("GRAYLOG_WEB_ENDPOINT_URI")
+
+	if endpoint == "" {
+		defer gock.Off()
+		endpoint = "http://example.com/api"
+		client, err := client.NewClient(endpoint, authName, authPass)
+		assert.Nil(t, err)
+		data := []struct {
+			statusCode int
+			resp       string
+			checkErr   func(assert.TestingT, interface{}, ...interface{}) bool
+		}{{
+			statusCode: 200,
+			resp:       `{"foo": "Reader"}`,
+			checkErr:   assert.Nil,
+		}}
+		for _, d := range data {
+			gock.New("http://example.com").
+				Get("/api/system/ldap/settings/groups").
+				MatchType("json").Reply(d.statusCode).BodyString(d.resp)
+			m, _, err := client.GetLDAPGroupRoleMapping()
+			if err != nil {
+				assert.Equal(t, d.resp, m)
+			}
+			d.checkErr(t, err)
+		}
+	}
+}
+
+func TestUpdateLDAPGroupRoleMapping(t *testing.T) {
+	authName := os.Getenv("GRAYLOG_AUTH_NAME")
+	authPass := os.Getenv("GRAYLOG_AUTH_PASSWORD")
+	endpoint := os.Getenv("GRAYLOG_WEB_ENDPOINT_URI")
+
+	if endpoint == "" {
+		defer gock.Off()
+		endpoint = "http://example.com/api"
+		client, err := client.NewClient(endpoint, authName, authPass)
+		assert.Nil(t, err)
+		data := []struct {
+			statusCode int
+			body       string
+			mapping    map[string]string
+			checkErr   func(assert.TestingT, interface{}, ...interface{}) bool
+		}{{
+			statusCode: 204,
+			body:       `{"foo": "Reader"}`,
+			mapping:    map[string]string{"foo": "Reader"},
+			checkErr:   assert.Nil,
+		}}
+		for _, d := range data {
+			gock.New("http://example.com").
+				Put("/api/system/ldap/settings/groups").
+				MatchType("json").BodyString(d.body).Reply(d.statusCode)
+			_, err := client.UpdateLDAPGroupRoleMapping(d.mapping)
+			d.checkErr(t, err)
+		}
+	}
+}

--- a/client/ldap_setting.go
+++ b/client/ldap_setting.go
@@ -51,3 +51,43 @@ func (client *Client) DeleteLDAPSettingContext(
 ) (*ErrorInfo, error) {
 	return client.callDelete(ctx, client.Endpoints().LDAPSetting(), nil, nil)
 }
+
+// GetLDAPGroups returns the available LDAP groups.
+func (client *Client) GetLDAPGroups() ([]string, *ErrorInfo, error) {
+	return client.GetLDAPGroupsContext(context.Background())
+}
+
+// GetLDAPGroupsContext returns the available LDAP groups with a context.
+func (client *Client) GetLDAPGroupsContext(ctx context.Context) ([]string, *ErrorInfo, error) {
+	// GET /system/ldap/groups Get the available LDAP groups
+	groups := []string{}
+	ei, err := client.callGet(
+		ctx, client.Endpoints().LDAPGroups(), nil, &groups)
+	return groups, ei, err
+}
+
+// GetLDAPGroupRoleMapping returns the LDAP group and role mapping.
+func (client *Client) GetLDAPGroupRoleMapping() (map[string]string, *ErrorInfo, error) {
+	return client.GetLDAPGroupRoleMappingContext(context.Background())
+}
+
+// GetLDAPGroupRoleMappingContext returns the LDAP group and role mapping with a context.
+func (client *Client) GetLDAPGroupRoleMappingContext(ctx context.Context) (map[string]string, *ErrorInfo, error) {
+	// GET /system/ldap/settings/groups Get the LDAP group to Graylog role mapping
+	m := map[string]string{}
+	ei, err := client.callGet(
+		ctx, client.Endpoints().LDAPGroupRoleMapping(), nil, &m)
+	return m, ei, err
+}
+
+// UpdateLDAPGroupRoleMapping updates the LDAP group and role mapping.
+func (client *Client) UpdateLDAPGroupRoleMapping(mapping map[string]string) (*ErrorInfo, error) {
+	return client.UpdateLDAPGroupRoleMappingContext(context.Background(), mapping)
+}
+
+// UpdateLDAPGroupRoleMappingContext returns the LDAP group and role mapping with a context.
+func (client *Client) UpdateLDAPGroupRoleMappingContext(ctx context.Context, mapping map[string]string) (*ErrorInfo, error) {
+	// PUT /system/ldap/settings/groups Update the LDAP group to Graylog role mapping
+	return client.callPut(
+		ctx, client.Endpoints().LDAPGroupRoleMapping(), mapping, nil)
+}

--- a/client/ldap_setting.go
+++ b/client/ldap_setting.go
@@ -24,7 +24,7 @@ func (client *Client) GetLDAPSettingContext(ctx context.Context) (
 }
 
 // UpdateLDAPSetting updates the LDAP setting.
-func (client *Client) UpdateLDAPSetting(ldapSetting *graylog.LDAPSettingUpdateParams) (
+func (client *Client) UpdateLDAPSetting(ldapSetting *graylog.LDAPSetting) (
 	*ErrorInfo, error,
 ) {
 	return client.UpdateLDAPSettingContext(context.Background(), ldapSetting)
@@ -32,7 +32,7 @@ func (client *Client) UpdateLDAPSetting(ldapSetting *graylog.LDAPSettingUpdatePa
 
 // UpdateLDAPSettingContext updates the LDAP setting with a context.
 func (client *Client) UpdateLDAPSettingContext(
-	ctx context.Context, prms *graylog.LDAPSettingUpdateParams,
+	ctx context.Context, prms *graylog.LDAPSetting,
 ) (*ErrorInfo, error) {
 	if prms == nil {
 		return nil, fmt.Errorf("ldap setting is nil")
@@ -50,44 +50,4 @@ func (client *Client) DeleteLDAPSettingContext(
 	ctx context.Context,
 ) (*ErrorInfo, error) {
 	return client.callDelete(ctx, client.Endpoints().LDAPSetting(), nil, nil)
-}
-
-// GetLDAPGroups returns the available LDAP groups.
-func (client *Client) GetLDAPGroups() ([]string, *ErrorInfo, error) {
-	return client.GetLDAPGroupsContext(context.Background())
-}
-
-// GetLDAPGroupsContext returns the available LDAP groups with a context.
-func (client *Client) GetLDAPGroupsContext(ctx context.Context) ([]string, *ErrorInfo, error) {
-	// GET /system/ldap/groups Get the available LDAP groups
-	groups := []string{}
-	ei, err := client.callGet(
-		ctx, client.Endpoints().LDAPGroups(), nil, &groups)
-	return groups, ei, err
-}
-
-// GetLDAPGroupRoleMapping returns the LDAP group and role mapping.
-func (client *Client) GetLDAPGroupRoleMapping() (map[string]string, *ErrorInfo, error) {
-	return client.GetLDAPGroupRoleMappingContext(context.Background())
-}
-
-// GetLDAPGroupRoleMappingContext returns the LDAP group and role mapping with a context.
-func (client *Client) GetLDAPGroupRoleMappingContext(ctx context.Context) (map[string]string, *ErrorInfo, error) {
-	// GET /system/ldap/settings/groups Get the LDAP group to Graylog role mapping
-	m := map[string]string{}
-	ei, err := client.callGet(
-		ctx, client.Endpoints().LDAPGroupRoleMapping(), nil, &m)
-	return m, ei, err
-}
-
-// UpdateLDAPGroupRoleMapping updates the LDAP group and role mapping.
-func (client *Client) UpdateLDAPGroupRoleMapping(mapping map[string]string) (*ErrorInfo, error) {
-	return client.UpdateLDAPGroupRoleMappingContext(context.Background(), mapping)
-}
-
-// UpdateLDAPGroupRoleMappingContext returns the LDAP group and role mapping with a context.
-func (client *Client) UpdateLDAPGroupRoleMappingContext(ctx context.Context, mapping map[string]string) (*ErrorInfo, error) {
-	// PUT /system/ldap/settings/groups Update the LDAP group to Graylog role mapping
-	return client.callPut(
-		ctx, client.Endpoints().LDAPGroupRoleMapping(), mapping, nil)
 }

--- a/client/ldap_setting_test.go
+++ b/client/ldap_setting_test.go
@@ -1,0 +1,107 @@
+package client_test
+
+import (
+	"os"
+	"testing"
+
+	"gopkg.in/h2non/gock.v1"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/suzuki-shunsuke/go-graylog/client"
+)
+
+func TestGetLDAPGroups(t *testing.T) {
+	authName := os.Getenv("GRAYLOG_AUTH_NAME")
+	authPass := os.Getenv("GRAYLOG_AUTH_PASSWORD")
+	endpoint := os.Getenv("GRAYLOG_WEB_ENDPOINT_URI")
+
+	if endpoint == "" {
+		defer gock.Off()
+		endpoint = "http://example.com/api"
+		client, err := client.NewClient(endpoint, authName, authPass)
+		assert.Nil(t, err)
+		data := []struct {
+			statusCode int
+			resp       string
+			checkErr   func(assert.TestingT, interface{}, ...interface{}) bool
+		}{{
+			statusCode: 200,
+			resp:       `["foo"]`,
+			checkErr:   assert.Nil,
+		}}
+		for _, d := range data {
+			gock.New("http://example.com").
+				Get("/api/system/ldap/groups").
+				MatchType("json").Reply(d.statusCode).BodyString(d.resp)
+			m, _, err := client.GetLDAPGroups()
+			if err != nil {
+				assert.Equal(t, d.resp, m)
+			}
+			d.checkErr(t, err)
+		}
+	}
+}
+
+func TestGetLDAPGroupRoleMapping(t *testing.T) {
+	authName := os.Getenv("GRAYLOG_AUTH_NAME")
+	authPass := os.Getenv("GRAYLOG_AUTH_PASSWORD")
+	endpoint := os.Getenv("GRAYLOG_WEB_ENDPOINT_URI")
+
+	if endpoint == "" {
+		defer gock.Off()
+		endpoint = "http://example.com/api"
+		client, err := client.NewClient(endpoint, authName, authPass)
+		assert.Nil(t, err)
+		data := []struct {
+			statusCode int
+			resp       string
+			checkErr   func(assert.TestingT, interface{}, ...interface{}) bool
+		}{{
+			statusCode: 200,
+			resp:       `{"foo": "Reader"}`,
+			checkErr:   assert.Nil,
+		}}
+		for _, d := range data {
+			gock.New("http://example.com").
+				Get("/api/system/ldap/settings/groups").
+				MatchType("json").Reply(d.statusCode).BodyString(d.resp)
+			m, _, err := client.GetLDAPGroupRoleMapping()
+			if err != nil {
+				assert.Equal(t, d.resp, m)
+			}
+			d.checkErr(t, err)
+		}
+	}
+}
+
+func TestUpdateLDAPGroupRoleMapping(t *testing.T) {
+	authName := os.Getenv("GRAYLOG_AUTH_NAME")
+	authPass := os.Getenv("GRAYLOG_AUTH_PASSWORD")
+	endpoint := os.Getenv("GRAYLOG_WEB_ENDPOINT_URI")
+
+	if endpoint == "" {
+		defer gock.Off()
+		endpoint = "http://example.com/api"
+		client, err := client.NewClient(endpoint, authName, authPass)
+		assert.Nil(t, err)
+		data := []struct {
+			statusCode int
+			body       string
+			mapping    map[string]string
+			checkErr   func(assert.TestingT, interface{}, ...interface{}) bool
+		}{{
+			statusCode: 204,
+			body:       `{"foo": "Reader"}`,
+			mapping:    map[string]string{"foo": "Reader"},
+			checkErr:   assert.Nil,
+		}}
+		for _, d := range data {
+			gock.New("http://example.com").
+				Put("/api/system/ldap/settings/groups").
+				MatchType("json").BodyString(d.body).Reply(d.statusCode)
+			_, err := client.UpdateLDAPGroupRoleMapping(d.mapping)
+			d.checkErr(t, err)
+		}
+	}
+}

--- a/client/ldap_setting_test.go
+++ b/client/ldap_setting_test.go
@@ -7,11 +7,13 @@ import (
 	"gopkg.in/h2non/gock.v1"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/suzuki-shunsuke/go-set"
 
+	"github.com/suzuki-shunsuke/go-graylog"
 	"github.com/suzuki-shunsuke/go-graylog/client"
 )
 
-func TestGetLDAPGroups(t *testing.T) {
+func TestGetLDAPSetting(t *testing.T) {
 	authName := os.Getenv("GRAYLOG_AUTH_NAME")
 	authPass := os.Getenv("GRAYLOG_AUTH_PASSWORD")
 	endpoint := os.Getenv("GRAYLOG_WEB_ENDPOINT_URI")
@@ -24,58 +26,58 @@ func TestGetLDAPGroups(t *testing.T) {
 		data := []struct {
 			statusCode int
 			resp       string
+			setting    *graylog.LDAPSetting
 			checkErr   func(assert.TestingT, interface{}, ...interface{}) bool
 		}{{
 			statusCode: 200,
-			resp:       `["foo"]`,
-			checkErr:   assert.Nil,
+			resp: `{
+  "enabled": true,
+  "system_username": "CN=admin",
+  "system_password": "***",
+  "ldap_uri": "ldap://ldap.example.com:389/",
+  "use_start_tls": false,
+  "trust_all_certificates": false,
+  "active_directory": false,
+  "search_base": "OU=user,OU=foo,DC=example,DC=com",
+  "search_pattern": "(cn={0})",
+  "display_name_attribute": "displayname",
+  "default_group": "Reader",
+  "group_mapping": {
+    "foo": "Reader"
+  },
+  "group_search_base": "",
+  "group_id_attribute": "",
+  "additional_default_groups": [],
+  "group_search_pattern": ""
+}`,
+			setting: &graylog.LDAPSetting{
+				Enabled:                 true,
+				SystemUsername:          "admin",
+				SystemPassword:          "***",
+				LDAPURI:                 "ldap://ldap.example.com:389/",
+				SearchBase:              "OU=user,OU=foo,DC=example,DC=com",
+				SearchPattern:           "(cn={0})",
+				DisplayNameAttribute:    "displayname",
+				DefaultGroup:            "Reader",
+				GroupMapping:            map[string]string{"foo": "Reader"},
+				AdditionalDefaultGroups: set.StrSet{},
+			},
+			checkErr: assert.Nil,
 		}}
 		for _, d := range data {
 			gock.New("http://example.com").
-				Get("/api/system/ldap/groups").
+				Get("/api/system/ldap/settings").
 				MatchType("json").Reply(d.statusCode).BodyString(d.resp)
-			m, _, err := client.GetLDAPGroups()
+			m, _, err := client.GetLDAPSetting()
 			if err != nil {
-				assert.Equal(t, d.resp, m)
+				assert.Equal(t, d.setting, m)
 			}
 			d.checkErr(t, err)
 		}
 	}
 }
 
-func TestGetLDAPGroupRoleMapping(t *testing.T) {
-	authName := os.Getenv("GRAYLOG_AUTH_NAME")
-	authPass := os.Getenv("GRAYLOG_AUTH_PASSWORD")
-	endpoint := os.Getenv("GRAYLOG_WEB_ENDPOINT_URI")
-
-	if endpoint == "" {
-		defer gock.Off()
-		endpoint = "http://example.com/api"
-		client, err := client.NewClient(endpoint, authName, authPass)
-		assert.Nil(t, err)
-		data := []struct {
-			statusCode int
-			resp       string
-			checkErr   func(assert.TestingT, interface{}, ...interface{}) bool
-		}{{
-			statusCode: 200,
-			resp:       `{"foo": "Reader"}`,
-			checkErr:   assert.Nil,
-		}}
-		for _, d := range data {
-			gock.New("http://example.com").
-				Get("/api/system/ldap/settings/groups").
-				MatchType("json").Reply(d.statusCode).BodyString(d.resp)
-			m, _, err := client.GetLDAPGroupRoleMapping()
-			if err != nil {
-				assert.Equal(t, d.resp, m)
-			}
-			d.checkErr(t, err)
-		}
-	}
-}
-
-func TestUpdateLDAPGroupRoleMapping(t *testing.T) {
+func TestUpdateLDAPSetting(t *testing.T) {
 	authName := os.Getenv("GRAYLOG_AUTH_NAME")
 	authPass := os.Getenv("GRAYLOG_AUTH_PASSWORD")
 	endpoint := os.Getenv("GRAYLOG_WEB_ENDPOINT_URI")
@@ -88,19 +90,41 @@ func TestUpdateLDAPGroupRoleMapping(t *testing.T) {
 		data := []struct {
 			statusCode int
 			body       string
-			mapping    map[string]string
+			setting    *graylog.LDAPSetting
 			checkErr   func(assert.TestingT, interface{}, ...interface{}) bool
 		}{{
 			statusCode: 204,
-			body:       `{"foo": "Reader"}`,
-			mapping:    map[string]string{"foo": "Reader"},
-			checkErr:   assert.Nil,
+			body: `{
+  "enabled": true,
+  "system_username": "admin",
+  "system_password": "***",
+  "ldap_uri": "ldap://ldap.example.com:389/",
+  "search_base": "OU=user,OU=foo,DC=example,DC=com",
+  "search_pattern": "(cn={0})",
+  "display_name_attribute": "displayname",
+  "default_group": "Reader",
+  "group_mapping": {
+    "foo": "Reader"
+  }
+}`,
+			setting: &graylog.LDAPSetting{
+				Enabled:              true,
+				SystemUsername:       "admin",
+				SystemPassword:       "***",
+				LDAPURI:              "ldap://ldap.example.com:389/",
+				SearchBase:           "OU=user,OU=foo,DC=example,DC=com",
+				SearchPattern:        "(cn={0})",
+				DisplayNameAttribute: "displayname",
+				DefaultGroup:         "Reader",
+				GroupMapping:         map[string]string{"foo": "Reader"},
+			},
+			checkErr: assert.Nil,
 		}}
 		for _, d := range data {
 			gock.New("http://example.com").
-				Put("/api/system/ldap/settings/groups").
+				Put("/api/system/ldap/settings").
 				MatchType("json").BodyString(d.body).Reply(d.statusCode)
-			_, err := client.UpdateLDAPGroupRoleMapping(d.mapping)
+			_, err := client.UpdateLDAPSetting(d.setting)
 			d.checkErr(t, err)
 		}
 	}

--- a/ldap_setting.go
+++ b/ldap_setting.go
@@ -1,65 +1,25 @@
 package graylog
 
 import (
-	"github.com/suzuki-shunsuke/go-ptr"
+	"github.com/suzuki-shunsuke/go-set"
 )
 
 // LDAPSetting represents a ldap settings.
 type LDAPSetting struct {
-	Enabled                 bool              `json:"enabled"`
-	UseStartTLS             bool              `json:"use_start_tls"`
-	TrustAllCertificates    bool              `json:"trust_all_certificates"`
-	ActiveDirectory         bool              `json:"active_directory"`
-	SystemUsername          string            `json:"system_username,omitempty"`
-	SystemPassword          string            `json:"system_password"`
-	LDAPURI                 string            `json:"ldap_uri"`
-	SearchBase              string            `json:"search_base"`
-	SearchPattern           string            `json:"search_pattern"`
-	DisplayNameAttribute    string            `json:"display_name_attribute"`
-	DefaultGroup            string            `json:"default_group"`
-	GroupSearchBase         string            `json:"group_search_base"`
-	GroupIDAttribute        string            `json:"group_id_attribute"`
-	GroupSearchPattern      string            `json:"group_search_pattern"`
-	GroupMapping            map[string]string `json:"group_mapping"`
-	AdditionalDefaultGroups []string          `json:"additional_default_groups"`
-}
-
-// LDAPSettingUpdateParams represents Update LDAP Setting API's parameters.
-type LDAPSettingUpdateParams struct {
-	Enabled                 *bool             `json:"enabled"`
-	UseStartTLS             *bool             `json:"use_start_tls"`
-	TrustAllCertificates    *bool             `json:"trust_all_certificates"`
-	ActiveDirectory         *bool             `json:"active_directory"`
-	SystemUsername          *string           `json:"system_username,omitempty"`
-	SystemPassword          *string           `json:"system_password"`
-	LDAPURI                 *string           `json:"ldap_uri"`
-	SearchBase              *string           `json:"search_base"`
-	SearchPattern           *string           `json:"search_pattern"`
-	DisplayNameAttribute    *string           `json:"display_name_attribute"`
-	DefaultGroup            *string           `json:"default_group"`
-	GroupSearchBase         *string           `json:"group_search_base"`
-	GroupIDAttribute        *string           `json:"group_id_attribute"`
-	GroupSearchPattern      *string           `json:"group_search_pattern"`
-	GroupMapping            map[string]string `json:"group_mapping"`
-	AdditionalDefaultGroups []string          `json:"additional_default_groups"`
-}
-
-// NewUpdateParams returns Update LDAP Setting API's parameters.
-func (ls *LDAPSetting) NewUpdateParams() *LDAPSettingUpdateParams {
-	return &LDAPSettingUpdateParams{
-		Enabled:              ptr.PBool(ls.Enabled),
-		UseStartTLS:          ptr.PBool(ls.UseStartTLS),
-		TrustAllCertificates: ptr.PBool(ls.TrustAllCertificates),
-		ActiveDirectory:      ptr.PBool(ls.ActiveDirectory),
-		SystemUsername:       ptr.PStr(ls.SystemUsername),
-		SystemPassword:       ptr.PStr(ls.SystemPassword),
-		LDAPURI:              ptr.PStr(ls.LDAPURI),
-		SearchBase:           ptr.PStr(ls.SearchBase),
-		SearchPattern:        ptr.PStr(ls.SearchPattern),
-		DisplayNameAttribute: ptr.PStr(ls.DisplayNameAttribute),
-		DefaultGroup:         ptr.PStr(ls.DefaultGroup),
-		GroupSearchBase:      ptr.PStr(ls.GroupSearchBase),
-		GroupIDAttribute:     ptr.PStr(ls.GroupIDAttribute),
-		GroupSearchPattern:   ptr.PStr(ls.GroupSearchPattern),
-	}
+	Enabled                 bool              `json:"enabled,omitempty"`
+	UseStartTLS             bool              `json:"use_start_tls,omitempty"`
+	TrustAllCertificates    bool              `json:"trust_all_certificates,omitempty"`
+	ActiveDirectory         bool              `json:"active_directory,omitempty"`
+	SystemUsername          string            `json:"system_username" v-create:"required" v-update:"required"`
+	SystemPassword          string            `json:"system_password" v-create:"required" v-update:"required"`
+	LDAPURI                 string            `json:"ldap_uri" v-create:"required" v-update:"required"`
+	SearchBase              string            `json:"search_base" v-create:"required" v-update:"required"`
+	SearchPattern           string            `json:"search_pattern" v-create:"required" v-update:"required"`
+	DisplayNameAttribute    string            `json:"display_name_attribute" v-create:"required" v-update:"required"`
+	DefaultGroup            string            `json:"default_group" v-create:"required" v-update:"required"`
+	GroupSearchBase         string            `json:"group_search_base,omitempty"`
+	GroupIDAttribute        string            `json:"group_id_attribute,omitempty"`
+	GroupSearchPattern      string            `json:"group_search_pattern,omitempty"`
+	GroupMapping            map[string]string `json:"group_mapping,omitempty"`
+	AdditionalDefaultGroups set.StrSet        `json:"additional_default_groups,omitempty"`
 }

--- a/ldap_setting.go
+++ b/ldap_setting.go
@@ -6,42 +6,42 @@ import (
 
 // LDAPSetting represents a ldap settings.
 type LDAPSetting struct {
-	Enabled              bool   `json:"enabled"`
-	UseStartTLS          bool   `json:"use_start_tls"`
-	TrustAllCertificates bool   `json:"trust_all_certificates"`
-	ActiveDirectory      bool   `json:"active_directory"`
-	SystemUsername       string `json:"system_username,omitempty"`
-	SystemPassword       string `json:"system_password"`
-	LDAPURI              string `json:"ldap_uri"`
-	SearchBase           string `json:"search_base"`
-	SearchPattern        string `json:"search_pattern"`
-	DisplayNameAttribute string `json:"display_name_attribute"`
-	DefaultGroup         string `json:"default_group"`
-	GroupSearchBase      string `json:"group_search_base"`
-	GroupIDAttribute     string `json:"group_id_attribute"`
-	GroupSearchPattern   string `json:"group_search_pattern"`
-	// GroupMapping            interface{} `json:"group_mapping"`
-	// AdditionalDefaultGroups interface{} `json:"additional_default_groups"`
+	Enabled                 bool              `json:"enabled"`
+	UseStartTLS             bool              `json:"use_start_tls"`
+	TrustAllCertificates    bool              `json:"trust_all_certificates"`
+	ActiveDirectory         bool              `json:"active_directory"`
+	SystemUsername          string            `json:"system_username,omitempty"`
+	SystemPassword          string            `json:"system_password"`
+	LDAPURI                 string            `json:"ldap_uri"`
+	SearchBase              string            `json:"search_base"`
+	SearchPattern           string            `json:"search_pattern"`
+	DisplayNameAttribute    string            `json:"display_name_attribute"`
+	DefaultGroup            string            `json:"default_group"`
+	GroupSearchBase         string            `json:"group_search_base"`
+	GroupIDAttribute        string            `json:"group_id_attribute"`
+	GroupSearchPattern      string            `json:"group_search_pattern"`
+	GroupMapping            map[string]string `json:"group_mapping"`
+	AdditionalDefaultGroups []string          `json:"additional_default_groups"`
 }
 
 // LDAPSettingUpdateParams represents Update LDAP Setting API's parameters.
 type LDAPSettingUpdateParams struct {
-	Enabled              *bool   `json:"enabled"`
-	UseStartTLS          *bool   `json:"use_start_tls"`
-	TrustAllCertificates *bool   `json:"trust_all_certificates"`
-	ActiveDirectory      *bool   `json:"active_directory"`
-	SystemUsername       *string `json:"system_username,omitempty"`
-	SystemPassword       *string `json:"system_password"`
-	LDAPURI              *string `json:"ldap_uri"`
-	SearchBase           *string `json:"search_base"`
-	SearchPattern        *string `json:"search_pattern"`
-	DisplayNameAttribute *string `json:"display_name_attribute"`
-	DefaultGroup         *string `json:"default_group"`
-	GroupSearchBase      *string `json:"group_search_base"`
-	GroupIDAttribute     *string `json:"group_id_attribute"`
-	GroupSearchPattern   *string `json:"group_search_pattern"`
-	// GroupMapping            interface{} `json:"group_mapping"`
-	// AdditionalDefaultGroups interface{} `json:"additional_default_groups"`
+	Enabled                 *bool             `json:"enabled"`
+	UseStartTLS             *bool             `json:"use_start_tls"`
+	TrustAllCertificates    *bool             `json:"trust_all_certificates"`
+	ActiveDirectory         *bool             `json:"active_directory"`
+	SystemUsername          *string           `json:"system_username,omitempty"`
+	SystemPassword          *string           `json:"system_password"`
+	LDAPURI                 *string           `json:"ldap_uri"`
+	SearchBase              *string           `json:"search_base"`
+	SearchPattern           *string           `json:"search_pattern"`
+	DisplayNameAttribute    *string           `json:"display_name_attribute"`
+	DefaultGroup            *string           `json:"default_group"`
+	GroupSearchBase         *string           `json:"group_search_base"`
+	GroupIDAttribute        *string           `json:"group_id_attribute"`
+	GroupSearchPattern      *string           `json:"group_search_pattern"`
+	GroupMapping            map[string]string `json:"group_mapping"`
+	AdditionalDefaultGroups []string          `json:"additional_default_groups"`
 }
 
 // NewUpdateParams returns Update LDAP Setting API's parameters.

--- a/mockserver/handler/ldap_setting.go
+++ b/mockserver/handler/ldap_setting.go
@@ -29,13 +29,15 @@ func HandleUpdateLDAPSetting(
 	}
 	body, sc, err := validateRequestBody(
 		r.Body, &validateReqBodyPrms{
-			Required: nil,
+			Required: set.NewStrSet(
+				"display_name_attribute", "system_username", "search_base",
+				"system_password", "ldap_uri", "search_pattern", "default_group",
+			),
 			Optional: set.NewStrSet(
-				"enabled", "display_name_attribute", "system_username", "search_base",
-				"additional_default_groups", "system_password", "group_mapping",
-				"ldap_uri", "group_id_attribute", "search_pattern",
+				"enabled", "additional_default_groups", "group_mapping",
+				"group_id_attribute",
 				"trust_all_certificates", "use_start_tls", "group_search_base",
-				"active_directory", "group_search_pattern", "default_group"),
+				"active_directory", "group_search_pattern"),
 			Ignored:      nil,
 			ExtForbidden: true,
 		})
@@ -43,7 +45,7 @@ func HandleUpdateLDAPSetting(
 		return nil, sc, err
 	}
 
-	prms := &graylog.LDAPSettingUpdateParams{}
+	prms := &graylog.LDAPSetting{}
 	if err := util.MSDecode(body, prms); err != nil {
 		lgc.Logger().WithFields(log.Fields{
 			"body": body, "error": err,

--- a/mockserver/logic/ldap_setting.go
+++ b/mockserver/logic/ldap_setting.go
@@ -15,7 +15,7 @@ func (lgc *Logic) GetLDAPSetting() (*graylog.LDAPSetting, int, error) {
 }
 
 // UpdateLDAPSetting updates a LDAP Setting.
-func (lgc *Logic) UpdateLDAPSetting(prms *graylog.LDAPSettingUpdateParams) (int, error) {
+func (lgc *Logic) UpdateLDAPSetting(prms *graylog.LDAPSetting) (int, error) {
 	if err := validator.UpdateValidator.Struct(prms); err != nil {
 		return 400, err
 	}

--- a/mockserver/store/plain/ldap_setting.go
+++ b/mockserver/store/plain/ldap_setting.go
@@ -18,58 +18,11 @@ func (store *Store) GetLDAPSetting() (*graylog.LDAPSetting, error) {
 }
 
 // UpdateLDAPSetting updates a LDAP Setting at the store.
-func (store *Store) UpdateLDAPSetting(prms *graylog.LDAPSettingUpdateParams) error {
+func (store *Store) UpdateLDAPSetting(prms *graylog.LDAPSetting) error {
 	store.imutex.Lock()
 	defer store.imutex.Unlock()
-	ls := store.ldapSetting
-	if ls == nil {
-		ls = defaultLDAPSetting()
-	}
-
-	if prms.Enabled != nil {
-		ls.Enabled = *prms.Enabled
-	}
-	if prms.UseStartTLS != nil {
-		ls.UseStartTLS = *prms.UseStartTLS
-	}
-	if prms.TrustAllCertificates != nil {
-		ls.TrustAllCertificates = *prms.TrustAllCertificates
-	}
-	if prms.ActiveDirectory != nil {
-		ls.ActiveDirectory = *prms.ActiveDirectory
-	}
-	if prms.SystemUsername != nil {
-		ls.SystemUsername = *prms.SystemUsername
-	}
-	if prms.SystemPassword != nil {
-		ls.SystemPassword = *prms.SystemPassword
-	}
-	if prms.LDAPURI != nil {
-		ls.LDAPURI = *prms.LDAPURI
-	}
-	if prms.SearchBase != nil {
-		ls.SearchBase = *prms.SearchBase
-	}
-	if prms.SearchPattern != nil {
-		ls.SearchPattern = *prms.SearchPattern
-	}
-	if prms.DisplayNameAttribute != nil {
-		ls.DisplayNameAttribute = *prms.DisplayNameAttribute
-	}
-	if prms.DefaultGroup != nil {
-		ls.DefaultGroup = *prms.DefaultGroup
-	}
-	if prms.GroupSearchBase != nil {
-		ls.GroupSearchBase = *prms.GroupSearchBase
-	}
-	if prms.GroupIDAttribute != nil {
-		ls.GroupIDAttribute = *prms.GroupIDAttribute
-	}
-	if prms.GroupSearchPattern != nil {
-		ls.GroupSearchPattern = *prms.GroupSearchPattern
-	}
-
-	store.ldapSetting = ls
+	p := *prms
+	store.ldapSetting = &p
 	return nil
 }
 

--- a/mockserver/store/store.go
+++ b/mockserver/store/store.go
@@ -103,6 +103,6 @@ type Store interface {
 	GetAlarmCallbacks() ([]graylog.AlarmCallback, int, error)
 
 	GetLDAPSetting() (*graylog.LDAPSetting, error)
-	UpdateLDAPSetting(*graylog.LDAPSettingUpdateParams) error
+	UpdateLDAPSetting(*graylog.LDAPSetting) error
 	DeleteLDAPSetting() error
 }

--- a/terraform/docs/ldap_setting.md
+++ b/terraform/docs/ldap_setting.md
@@ -5,19 +5,22 @@ https://github.com/suzuki-shunsuke/terraform-provider-graylog/blob/master/resour
 ```
 resource "graylog_ldap_setting" "foo" {
   enabled = true
-  system_username = ""
-  system_password = ""
+  system_username = "admin"
+  system_password = "password"
   ldap_uri = "ldap://localhost:389"
   use_start_tls = false
   trust_all_certificates = false
   active_directory = false
-  search_base = ""
-  search_pattern = ""
-  display_name_attribute = ""
-  default_group = ""
+  search_base = "OU=user,OU=foo,DC=example,DC=com"
+  search_pattern = "(cn={0})"
+  display_name_attribute = "displayname"
+  default_group = "Reader"
   group_search_base = ""
   group_id_attribute = ""
   group_search_pattern = ""
+  group_mapping = {
+    foo = "Reader"
+  }
 }
 ```
 
@@ -32,7 +35,15 @@ terraform import graylog_ldap_setting.foo bar
 
 ### Required Argument
 
-Nothing.
+name | default | type | description
+--- | --- | --- | ---
+system_username | "" | string |
+ldap_uri | "ldap://localhost:389" | string |
+search_base | "" | string |
+search_pattern | "" | string |
+display_name_attribute | "" | string |
+system_password | "" | string | sensitive
+default_group | "" | string |
 
 ### Optional Argument
 
@@ -40,16 +51,10 @@ name | default | type | description
 --- | --- | --- | ---
 description | "" | string |
 enabled | false | bool |
-system_username | "" | string |
-ldap_uri | "ldap://localhost:389" | string |
 use_start_tls | false | bool |
 trust_all_certificates | false | bool |
 active_directory | false | bool |
-search_base | "" | string |
-search_pattern | "" | string |
-display_name_attribute | "" | string |
 group_search_base | "" | string |
 group_id_attribute | "" | string |
 group_search_pattern | "" | string |
-system_password | "" | string | sensitive
-default_group | "" | string | computed
+group_mapping | | map[string]string |

--- a/terraform/graylog/resource_ldap_setting_test.go
+++ b/terraform/graylog/resource_ldap_setting_test.go
@@ -78,23 +78,23 @@ func TestAccLDAPSetting(t *testing.T) {
 
 	createTf := `
 resource "graylog_ldap_setting" "test-terraform" {
-  enabled = true
-  system_username = ""
-  system_password = ""
+  system_username = "admin"
+  system_password = "password"
   ldap_uri = "ldap://localhost:389"
-  use_start_tls = false
-  trust_all_certificates = false
 	display_name_attribute = "displayname"
+	search_base = "OU=user,OU=foo,DC=example,DC=com"
+	search_pattern = "(cn={0})"
+	default_group = "Reader"
 }`
 	updateTf := `
 resource "graylog_ldap_setting" "test-terraform" {
-  enabled = false
-  system_username = ""
-  system_password = ""
+  system_username = "admin"
+  system_password = "password"
   ldap_uri = "ldap://localhost:389"
-  use_start_tls = false
-  trust_all_certificates = false
 	display_name_attribute = "displayname_updated"
+	search_base = "OU=user,OU=foo,DC=example,DC=com"
+	search_pattern = "(cn={0})"
+	default_group = "Reader"
 }`
 	if server != nil {
 		server.Start()

--- a/terraform/graylog/util.go
+++ b/terraform/graylog/util.go
@@ -79,6 +79,10 @@ func setStrListToRD(d *schema.ResourceData, key string, val []string) error {
 	return d.Set(key, val)
 }
 
+func setMapStrToStrToRD(d *schema.ResourceData, key string, val map[string]string) error {
+	return d.Set(key, val)
+}
+
 func setStrToRD(d *schema.ResourceData, key, val string) error {
 	return d.Set(key, val)
 }


### PR DESCRIPTION
* https://github.com/suzuki-shunsuke/go-graylog/issues/28
* https://github.com/suzuki-shunsuke/go-graylog/issues/27
* https://github.com/suzuki-shunsuke/go-graylog/issues/26

```
System/LDAP : LDAP settings
GET /system/ldap/groups Get the available LDAP groups
GET /system/ldap/settings/groups Get the LDAP group to Graylog role mapping
PUT /system/ldap/settings/groups Update the LDAP group to Graylog role mapping
```

Fix ldap_setting's terraform resource.

BREAKING CHANGE:

* remove LDAPSettingUpdateParams
* make some ldap_setting terraform resource's parameter required