### PR TITLE
feat: #69 support extractors API

### DIFF
--- a/client/endpoint/endpoint.go
+++ b/client/endpoint/endpoint.go
@@ -18,6 +18,7 @@ type Endpoints struct {
 	collectorConfigurations *url.URL
 	dashboards              *url.URL
 	enabledStreams          *url.URL
+	extractors              *url.URL
 	indexSets               *url.URL
 	indexSetStats           *url.URL
 	inputs                  *url.URL
@@ -103,6 +104,10 @@ func NewEndpoints(endpoint string) (*Endpoints, error) {
 	if err != nil {
 		return nil, err
 	}
+	extractors, err := urlJoin(ep, "system/inputs")
+	if err != nil {
+		return nil, err
+	}
 	return &Endpoints{
 		alarmCallbacks:          alarmCallbacks,
 		alerts:                  alerts,
@@ -110,6 +115,7 @@ func NewEndpoints(endpoint string) (*Endpoints, error) {
 		collectorConfigurations: collectorConfigurations,
 		dashboards:              dashboards,
 		enabledStreams:          enabledStreams,
+		extractors:              extractors,
 		indexSets:               indexSets,
 		indexSetStats:           indexSetStats,
 		inputs:                  inputs,

--- a/client/endpoint/extractors.go
+++ b/client/endpoint/extractors.go
@@ -1,0 +1,18 @@
+package endpoint
+
+import (
+	"fmt"
+	"net/url"
+)
+
+// Extractors returns an Extractor API's endpoint url.
+func (ep *Endpoints) Extractors(inputID string) (*url.URL, error) {
+	// /system/inputs/{inputID}/extractors
+	return urlJoin(ep.extractors, fmt.Sprintf("%s/extractors", inputID))
+}
+
+// Extractor returns an Extractor API's endpoint url.
+func (ep *Endpoints) Extractor(inputID string, extractorID string) (*url.URL, error) {
+	// /system/inputs/{inputID}/extractors/{extractorinputID}
+	return urlJoin(ep.extractors, fmt.Sprintf("%s/extractors/%s", inputID, extractorID))
+}

--- a/client/extractors.go
+++ b/client/extractors.go
@@ -1,0 +1,106 @@
+package client
+
+import (
+	"context"
+
+	"github.com/suzuki-shunsuke/go-graylog"
+)
+
+// GetInputExtractors returns all extractors of an input.
+func (client *Client) GetInputExtractors(inputID string) ([]graylog.Extractor, *ErrorInfo, error) {
+	return client.GetInputExtractorsContext(context.Background(), inputID)
+}
+
+// GetInputExtractorsContext returns all extractors of an input with a context.
+func (client *Client) GetInputExtractorsContext(ctx context.Context, inputID string) ([]graylog.Extractor, *ErrorInfo, error) {
+	extractors := &graylog.ExtractorsBody{}
+	u, err := client.Endpoints().Extractors(inputID)
+	if err != nil {
+		return nil, nil, err
+	}
+	ei, err := client.callGet(ctx, u.String(), nil, extractors)
+	return extractors.Extractors, ei, err
+}
+
+// GetInputExtractor returns an extractors of an input.
+func (client *Client) GetInputExtractor(inputID string, extractorID string) (*graylog.Extractor, *ErrorInfo, error) {
+	return client.GetInputExtractorContext(context.Background(), inputID, extractorID)
+}
+
+// GetInputExtractorContext returns an extractor of an input with a context.
+func (client *Client) GetInputExtractorContext(ctx context.Context, inputID string, extractorID string) (*graylog.Extractor, *ErrorInfo, error) {
+	extractor := &graylog.Extractor{}
+	u, err := client.Endpoints().Extractor(inputID, extractorID)
+	if err != nil {
+		return nil, nil, err
+	}
+	ei, err := client.callGet(ctx, u.String(), nil, extractor)
+	return extractor, ei, err
+}
+
+// CreateInputExtractor creates multiple extractors of an input.
+func (client *Client) CreateInputExtractor(extractor *graylog.Extractor, inputID string) (*ErrorInfo, error) {
+	return client.CreateInputExtractorContext(context.Background(), extractor, inputID)
+}
+
+// CreateInputExtractorContext creates multiple extractors of an input with a context.
+func (client *Client) CreateInputExtractorContext(ctx context.Context, extractor *graylog.Extractor, inputID string) (*ErrorInfo, error) {
+	u, err := client.Endpoints().Extractors(inputID)
+	if err != nil {
+		return nil, err
+	}
+	d := map[string]interface{}{
+		"title":            extractor.Title,
+		"cut_or_copy":      extractor.CursorStrategy,
+		"source_field":     extractor.SourceField,
+		"target_field":     extractor.TargetField,
+		"extractor_type":   extractor.Type,
+		"extractor_config": extractor.ExtractorConfig,
+		"converters":       map[string]interface{}{},
+		"condition_type":   extractor.ConditionType,
+		"condition_value":  extractor.ConditionValue,
+		"order":            extractor.Order,
+	}
+	return client.callPost(ctx, u.String(), d, nil)
+}
+
+// UpdateInputExtractor updates an extractor of an input.
+func (client *Client) UpdateInputExtractor(extractor *graylog.Extractor, inputID string) (*ErrorInfo, error) {
+	return client.UpdateInputExtractorContext(context.Background(), extractor, inputID)
+}
+
+// UpdateInputExtractorContext updates an extractor of an input with context.
+func (client *Client) UpdateInputExtractorContext(ctx context.Context, extractor *graylog.Extractor, inputID string) (*ErrorInfo, error) {
+	u, err := client.Endpoints().Extractor(inputID, extractor.ID)
+	if err != nil {
+		return nil, err
+	}
+	d := map[string]interface{}{
+		"title":            extractor.Title,
+		"cut_or_copy":      extractor.CursorStrategy,
+		"source_field":     extractor.SourceField,
+		"target_field":     extractor.TargetField,
+		"extractor_type":   extractor.Type,
+		"extractor_config": extractor.ExtractorConfig,
+		"converters":       map[string]interface{}{},
+		"condition_type":   extractor.ConditionType,
+		"condition_value":  extractor.ConditionValue,
+		"order":            extractor.Order,
+	}
+	ei, err := client.callPut(ctx, u.String(), d, nil)
+	return ei, err
+}
+
+// DeleteInputExtractor deletes an extractor of an input.
+func (client *Client) DeleteInputExtractor(inputID string, extractorID string) (*ErrorInfo, error) {
+	return client.DeleteInputExtractorContext(context.Background(), inputID, extractorID)
+}
+
+// DeleteInputExtractorContext deletes an extractor of an input with context.
+func (client *Client) DeleteInputExtractorContext(ctx context.Context, inputID string, extractorID string) (*ErrorInfo, error) {
+	u, err := client.Endpoints().Extractor(inputID, extractorID)
+	if err != nil {
+		return nil, err
+	}
+	return client.callDelete(ctx, u.String(), nil, nil)
+}

--- a/client/extractors.go
+++ b/client/extractors.go
@@ -6,29 +6,29 @@ import (
 	"github.com/suzuki-shunsuke/go-graylog"
 )
 
-// GetInputExtractors returns all extractors of an input.
-func (client *Client) GetInputExtractors(inputID string) ([]graylog.Extractor, *ErrorInfo, error) {
-	return client.GetInputExtractorsContext(context.Background(), inputID)
+// GetExtractors returns all extractors of an input.
+func (client *Client) GetExtractors(inputID string) ([]graylog.Extractor, int, *ErrorInfo, error) {
+	return client.GetExtractorsContext(context.Background(), inputID)
 }
 
-// GetInputExtractorsContext returns all extractors of an input with a context.
-func (client *Client) GetInputExtractorsContext(ctx context.Context, inputID string) ([]graylog.Extractor, *ErrorInfo, error) {
+// GetExtractorsContext returns all extractors of an input with a context.
+func (client *Client) GetExtractorsContext(ctx context.Context, inputID string) ([]graylog.Extractor, int, *ErrorInfo, error) {
 	extractors := &graylog.ExtractorsBody{}
 	u, err := client.Endpoints().Extractors(inputID)
 	if err != nil {
-		return nil, nil, err
+		return nil, 0, nil, err
 	}
 	ei, err := client.callGet(ctx, u.String(), nil, extractors)
-	return extractors.Extractors, ei, err
+	return extractors.Extractors, extractors.Total, ei, err
 }
 
-// GetInputExtractor returns an extractors of an input.
-func (client *Client) GetInputExtractor(inputID string, extractorID string) (*graylog.Extractor, *ErrorInfo, error) {
-	return client.GetInputExtractorContext(context.Background(), inputID, extractorID)
+// GetExtractor returns an extractors of an input.
+func (client *Client) GetExtractor(inputID, extractorID string) (*graylog.Extractor, *ErrorInfo, error) {
+	return client.GetExtractorContext(context.Background(), inputID, extractorID)
 }
 
-// GetInputExtractorContext returns an extractor of an input with a context.
-func (client *Client) GetInputExtractorContext(ctx context.Context, inputID string, extractorID string) (*graylog.Extractor, *ErrorInfo, error) {
+// GetExtractorContext returns an extractor of an input with a context.
+func (client *Client) GetExtractorContext(ctx context.Context, inputID, extractorID string) (*graylog.Extractor, *ErrorInfo, error) {
 	extractor := &graylog.Extractor{}
 	u, err := client.Endpoints().Extractor(inputID, extractorID)
 	if err != nil {
@@ -38,13 +38,13 @@ func (client *Client) GetInputExtractorContext(ctx context.Context, inputID stri
 	return extractor, ei, err
 }
 
-// CreateInputExtractor creates multiple extractors of an input.
-func (client *Client) CreateInputExtractor(extractor *graylog.Extractor, inputID string) (*ErrorInfo, error) {
-	return client.CreateInputExtractorContext(context.Background(), extractor, inputID)
+// CreateExtractor creates multiple extractors of an input.
+func (client *Client) CreateExtractor(extractor *graylog.Extractor, inputID string) (*ErrorInfo, error) {
+	return client.CreateExtractorContext(context.Background(), extractor, inputID)
 }
 
-// CreateInputExtractorContext creates multiple extractors of an input with a context.
-func (client *Client) CreateInputExtractorContext(ctx context.Context, extractor *graylog.Extractor, inputID string) (*ErrorInfo, error) {
+// CreateExtractorContext creates multiple extractors of an input with a context.
+func (client *Client) CreateExtractorContext(ctx context.Context, extractor *graylog.Extractor, inputID string) (*ErrorInfo, error) {
 	u, err := client.Endpoints().Extractors(inputID)
 	if err != nil {
 		return nil, err
@@ -64,13 +64,13 @@ func (client *Client) CreateInputExtractorContext(ctx context.Context, extractor
 	return client.callPost(ctx, u.String(), d, nil)
 }
 
-// UpdateInputExtractor updates an extractor of an input.
-func (client *Client) UpdateInputExtractor(extractor *graylog.Extractor, inputID string) (*ErrorInfo, error) {
-	return client.UpdateInputExtractorContext(context.Background(), extractor, inputID)
+// UpdateExtractor updates an extractor of an input.
+func (client *Client) UpdateExtractor(extractor *graylog.Extractor, inputID string) (*ErrorInfo, error) {
+	return client.UpdateExtractorContext(context.Background(), extractor, inputID)
 }
 
-// UpdateInputExtractorContext updates an extractor of an input with context.
-func (client *Client) UpdateInputExtractorContext(ctx context.Context, extractor *graylog.Extractor, inputID string) (*ErrorInfo, error) {
+// UpdateExtractorContext updates an extractor of an input with context.
+func (client *Client) UpdateExtractorContext(ctx context.Context, extractor *graylog.Extractor, inputID string) (*ErrorInfo, error) {
 	u, err := client.Endpoints().Extractor(inputID, extractor.ID)
 	if err != nil {
 		return nil, err
@@ -91,13 +91,13 @@ func (client *Client) UpdateInputExtractorContext(ctx context.Context, extractor
 	return ei, err
 }
 
-// DeleteInputExtractor deletes an extractor of an input.
-func (client *Client) DeleteInputExtractor(inputID string, extractorID string) (*ErrorInfo, error) {
-	return client.DeleteInputExtractorContext(context.Background(), inputID, extractorID)
+// DeleteExtractor deletes an extractor of an input.
+func (client *Client) DeleteExtractor(inputID, extractorID string) (*ErrorInfo, error) {
+	return client.DeleteExtractorContext(context.Background(), inputID, extractorID)
 }
 
-// DeleteInputExtractorContext deletes an extractor of an input with context.
-func (client *Client) DeleteInputExtractorContext(ctx context.Context, inputID string, extractorID string) (*ErrorInfo, error) {
+// DeleteExtractorContext deletes an extractor of an input with context.
+func (client *Client) DeleteExtractorContext(ctx context.Context, inputID, extractorID string) (*ErrorInfo, error) {
 	u, err := client.Endpoints().Extractor(inputID, extractorID)
 	if err != nil {
 		return nil, err

--- a/extractors.go
+++ b/extractors.go
@@ -1,0 +1,28 @@
+package graylog
+
+// Extractor represents a Graylog's Input Extractor.
+// http://docs.graylog.org/en/3.0/pages/extractors.html
+type Extractor struct {
+	ID                  string                   `json:"id,omitempty", v-create:"isdefault"`
+	Title               string                   `json:"title,omitempty", v-create:"required"`
+	Type                string                   `json:"type,omitempty", v-create:"required"`
+	CursorStrategy      string                   `json:"cursor_strategy,omitempty", v-create:"required"`
+	SourceField         string                   `json:"source_field,omitempty", v-create:"required"`
+	TargetField         string                   `json:"target_field,omitempty", v-create:"required"`
+	ExtractorConfig     map[string]interface{}   `json:"extractor_config,omitempty", v-create:"required"`
+	CreatorUserID       string                   `json:"creator_user_id,omitempty", v-create:"isdefault"`
+	Converters          []map[string]interface{} `json:"converters,omitempty", v-create:"required"`
+	ConditionType       string                   `json:"condition_type,omitempty", v-create:"required"`
+	ConditionValue      string                   `json:"condition_value,omitempty", v-create:"required"`
+	Order               int                      `json:"order,omitempty", v-create:"required"`
+	Exceptions          int                      `json:"exceptions,omitempty", v-create:"required"`
+	ConverterExceptions int                      `json:"converter_exceptions,omitempty", v-create:"required"`
+	Metrics             map[string]interface{}   `json:"metrics,omitempty", v-create:"required"`
+}
+
+// ExtractorsBody represents Get Extractors API's response body.
+// Basically users don't use this struct, but this struct is public because some sub packages use this struct.
+type ExtractorsBody struct {
+	Extractors []Extractor `json:"extractors"`
+	Total      int         `json:"total"`
+}

--- a/extractors.go
+++ b/extractors.go
@@ -3,21 +3,21 @@ package graylog
 // Extractor represents a Graylog's Input Extractor.
 // http://docs.graylog.org/en/3.0/pages/extractors.html
 type Extractor struct {
-	ID                  string                   `json:"id,omitempty", v-create:"isdefault"`
-	Title               string                   `json:"title,omitempty", v-create:"required"`
-	Type                string                   `json:"type,omitempty", v-create:"required"`
-	CursorStrategy      string                   `json:"cursor_strategy,omitempty", v-create:"required"`
-	SourceField         string                   `json:"source_field,omitempty", v-create:"required"`
-	TargetField         string                   `json:"target_field,omitempty", v-create:"required"`
-	ExtractorConfig     map[string]interface{}   `json:"extractor_config,omitempty", v-create:"required"`
-	CreatorUserID       string                   `json:"creator_user_id,omitempty", v-create:"isdefault"`
-	Converters          []map[string]interface{} `json:"converters,omitempty", v-create:"required"`
-	ConditionType       string                   `json:"condition_type,omitempty", v-create:"required"`
-	ConditionValue      string                   `json:"condition_value,omitempty", v-create:"required"`
-	Order               int                      `json:"order,omitempty", v-create:"required"`
-	Exceptions          int                      `json:"exceptions,omitempty", v-create:"required"`
-	ConverterExceptions int                      `json:"converter_exceptions,omitempty", v-create:"required"`
-	Metrics             map[string]interface{}   `json:"metrics,omitempty", v-create:"required"`
+	ID                  string                   `json:"id,omitempty" v-create:"isdefault"`
+	Title               string                   `json:"title,omitempty" v-create:"required"`
+	Type                string                   `json:"type,omitempty" v-create:"required"`
+	CursorStrategy      string                   `json:"cursor_strategy,omitempty" v-create:"required"`
+	SourceField         string                   `json:"source_field,omitempty" v-create:"required"`
+	TargetField         string                   `json:"target_field,omitempty" v-create:"required"`
+	ExtractorConfig     map[string]interface{}   `json:"extractor_config,omitempty" v-create:"required"`
+	CreatorUserID       string                   `json:"creator_user_id,omitempty" v-create:"isdefault"`
+	Converters          []map[string]interface{} `json:"converters,omitempty" v-create:"required"`
+	ConditionType       string                   `json:"condition_type,omitempty" v-create:"required"`
+	ConditionValue      string                   `json:"condition_value,omitempty" v-create:"required"`
+	Order               int                      `json:"order,omitempty" v-create:"required"`
+	Exceptions          int                      `json:"exceptions,omitempty" v-create:"required"`
+	ConverterExceptions int                      `json:"converter_exceptions,omitempty" v-create:"required"`
+	Metrics             map[string]interface{}   `json:"metrics,omitempty" v-create:"required"`
 }
 
 // ExtractorsBody represents Get Extractors API's response body.


### PR DESCRIPTION
Close #69 

Still left to do
- [ ] Terraform stuff (Maybe another PR?)
- [ ] Tests

I had an issue with the `Extractor.Converters` field and I'm not sure how to handle it. For now I send an empty interface instead of `extractor.Converters` in `CreateInputExtractorContext` and `UpdateInputExtractorContext`. When I send `extractor.Converters` as is I get an error:

> (*errors.errorString)(0xc0001e8140)(graylog API error: PUT https://**********/api/system/inputs/5c77f848555d3c000c04303c/extractors/86807560-3f2b-11e9-87c7-3242fc143566 400: Can not deserialize instance of java.util.LinkedHashMap out of START_ARRAY token 
at [Source: org.glassfish.jersey.message.internal.ReaderInterceptorExecutor$UnCloseableInputStream@63313b78; line: 1, column: 60] (through reference chain: org.graylog2.rest.models.system.inputs.extractors.requests.CreateExtractorRequest["converters"]))

I tried multiple types to send but it only accepts a `map[string]interface{}{}`. I can't simply define `Converters` in `Extractor` structure to `map[string]interface{}`, because when I do a GET request, I get this error:
> (*errors.withStack)(0xc000396800)(failed to decode graylog API response body: GET https://**********/api/system/inputs/5c77f848555d3c000c04303c/extractors: json: cannot unmarshal array into Go struct field Extractor.converters of type map[string]interface {})

Do you have an idea how to handle this @suzuki-shunsuke ?