### PR TITLE
feat: migrate terraform AlertCondition resource

### DIFF
--- a/alert_condition.go
+++ b/alert_condition.go
@@ -7,16 +7,70 @@ import (
 	"github.com/pkg/errors"
 )
 
-// AlertCondition represents an Alert Condition.
-// http://docs.graylog.org/en/2.4/pages/streams/alerts.html#conditions
-type AlertCondition struct {
-	ID            string                   `json:"id,omitempty"`
-	CreatorUserID string                   `json:"creator_user_id,omitempty"`
-	CreatedAt     string                   `json:"created_at,omitempty"`
-	Title         string                   `json:"title" v-create:"required" v-update:"required"`
-	InGrace       bool                     `json:"in_grace,omitempty"`
-	Parameters    AlertConditionParameters `json:"parameters" v-create:"reqired" v-update:"required"`
-}
+type (
+	// AlertCondition represents an Alert Condition.
+	// http://docs.graylog.org/en/2.4/pages/streams/alerts.html#conditions
+	AlertCondition struct {
+		ID            string                   `json:"id,omitempty"`
+		CreatorUserID string                   `json:"creator_user_id,omitempty"`
+		CreatedAt     string                   `json:"created_at,omitempty"`
+		Title         string                   `json:"title" v-create:"required" v-update:"required"`
+		InGrace       bool                     `json:"in_grace,omitempty"`
+		Parameters    AlertConditionParameters `json:"parameters" v-create:"reqired" v-update:"required"`
+	}
+
+	// AlertConditionParameters represents Alert Condition's parameters.
+	AlertConditionParameters interface {
+		AlertConditionType() string
+	}
+
+	// FieldContentAlertConditionParameters represents Field Content Alert Condition's parameters.
+	FieldContentAlertConditionParameters struct {
+		Grace               int    `json:"grace"`
+		Backlog             int    `json:"backlog"`
+		RepeatNotifications bool   `json:"repeat_notifications,omitempty"`
+		Field               string `json:"field,omitempty" v-create:"required"`
+		Value               string `json:"value,omitempty" v-create:"required"`
+		Query               string `json:"query,omitempty"`
+	}
+
+	// FieldAggregationAlertConditionParameters represents Field Aggregation Alert Condition's parameters.
+	FieldAggregationAlertConditionParameters struct {
+		Grace               int    `json:"grace"`
+		Backlog             int    `json:"backlog"`
+		Threshold           int    `json:"threshold"`
+		Time                int    `json:"time" v-create:"required"`
+		RepeatNotifications bool   `json:"repeat_notifications,omitempty"`
+		Field               string `json:"field,omitempty" v-create:"required"`
+		Query               string `json:"query,omitempty"`
+		ThresholdType       string `json:"threshold_type,omitempty" v-create:"required"`
+		Type                string `json:"type,omitempty" v-create:"required"`
+	}
+
+	// MessageCountAlertConditionParameters represents Field Aggregation Alert Condition's parameters.
+	MessageCountAlertConditionParameters struct {
+		Grace               int    `json:"grace"`
+		Backlog             int    `json:"backlog"`
+		Threshold           int    `json:"threshold"`
+		Time                int    `json:"time"`
+		RepeatNotifications bool   `json:"repeat_notifications,omitempty"`
+		Query               string `json:"query,omitempty"`
+		ThresholdType       string `json:"threshold_type,omitempty" v-create:"required"`
+	}
+
+	// AlertConditionsBody represents Get Alert Conditions API's response body.
+	// Basically users don't use this struct, but this struct is public because some sub packages use this struct.
+	AlertConditionsBody struct {
+		AlertConditions []AlertCondition `json:"conditions"`
+		Total           int              `json:"total"`
+	}
+
+	// GeneralAlertConditionParameters is a general third party's alert condition parameters.
+	GeneralAlertConditionParameters struct {
+		Type       string
+		Parameters map[string]interface{}
+	}
+)
 
 // Type returns an alert condition type.
 func (cond AlertCondition) Type() string {
@@ -91,37 +145,9 @@ func (cond *AlertCondition) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-// AlertConditionParameters represents Alert Condition's parameters.
-type AlertConditionParameters interface {
-	AlertConditionType() string
-}
-
-// FieldContentAlertConditionParameters represents Field Content Alert Condition's parameters.
-type FieldContentAlertConditionParameters struct {
-	Grace               int    `json:"grace"`
-	Backlog             int    `json:"backlog"`
-	RepeatNotifications bool   `json:"repeat_notifications,omitempty"`
-	Field               string `json:"field,omitempty" v-create:"required"`
-	Value               string `json:"value,omitempty" v-create:"required"`
-	Query               string `json:"query,omitempty"`
-}
-
 // AlertConditionType returns an alert condition type.
 func (p FieldContentAlertConditionParameters) AlertConditionType() string {
 	return "field_content_value"
-}
-
-// FieldAggregationAlertConditionParameters represents Field Aggregation Alert Condition's parameters.
-type FieldAggregationAlertConditionParameters struct {
-	Grace               int    `json:"grace"`
-	Backlog             int    `json:"backlog"`
-	Threshold           int    `json:"threshold"`
-	Time                int    `json:"time" v-create:"required"`
-	RepeatNotifications bool   `json:"repeat_notifications,omitempty"`
-	Field               string `json:"field,omitempty" v-create:"required"`
-	Query               string `json:"query,omitempty"`
-	ThresholdType       string `json:"threshold_type,omitempty" v-create:"required"`
-	Type                string `json:"type,omitempty" v-create:"required"`
 }
 
 // AlertConditionType returns an alert condition type.
@@ -129,33 +155,9 @@ func (p FieldAggregationAlertConditionParameters) AlertConditionType() string {
 	return "field_value"
 }
 
-// MessageCountAlertConditionParameters represents Field Aggregation Alert Condition's parameters.
-type MessageCountAlertConditionParameters struct {
-	Grace               int    `json:"grace"`
-	Backlog             int    `json:"backlog"`
-	Threshold           int    `json:"threshold"`
-	Time                int    `json:"time"`
-	RepeatNotifications bool   `json:"repeat_notifications,omitempty"`
-	Query               string `json:"query,omitempty"`
-	ThresholdType       string `json:"threshold_type,omitempty" v-create:"required"`
-}
-
 // AlertConditionType returns an alert condition type.
 func (p MessageCountAlertConditionParameters) AlertConditionType() string {
 	return "message_count"
-}
-
-// AlertConditionsBody represents Get Alert Conditions API's response body.
-// Basically users don't use this struct, but this struct is public because some sub packages use this struct.
-type AlertConditionsBody struct {
-	AlertConditions []AlertCondition `json:"conditions"`
-	Total           int              `json:"total"`
-}
-
-// GeneralAlertConditionParameters is a general third party's alert condition parameters.
-type GeneralAlertConditionParameters struct {
-	Type       string
-	Parameters map[string]interface{}
 }
 
 // AlertConditionType returns an alert condition type.

--- a/terraform/docs/alert_condition.md
+++ b/terraform/docs/alert_condition.md
@@ -20,9 +20,11 @@ resource "graylog_alert_condition" "test-terraform" {
 }
 ```
 
-## Argument Reference
+## Breaking Changes
 
-`parameters`'s fields depend on alert condition's type.
+* v1 -> v2: https://github.com/suzuki-shunsuke/go-graylog/issues/76
+
+## Argument Reference
 
 ### Common Required Argument
 
@@ -30,7 +32,6 @@ name | type | description
 --- | --- | ---
 type | string |
 title | string |
-parameters | |
 
 ### Common Optional Argument
 
@@ -40,21 +41,38 @@ in_grace | bool |
 
 ## type: field_content_value 
 
+```
+resource "graylog_alert_condition" "test-terraform" {
+  type = "field_content_value"
+  stream_id = "${graylog_stream.test-terraform.id}"
+  in_grace = false
+  title = "test"
+  field_content_value_parameters = {
+    field = "message"
+    value = "hoge hoge"
+    backlog = 1
+    repeat_notifications = false
+    query = "*"
+    grace = 0
+  }
+}
+```
+
 ### Required Argument
 
 name | type | description
 --- | --- | ---
-parameters.field | string |
-parameters.value | string |
+field_content_value_parameters.field | string |
+field_content_value_parameters.value | string |
 
 ### Optional Argument
 
 name | default | type | description
 --- | --- | --- | ---
-parameters.grace | 0 | int |
-parameters.backlog | 0 | int |
-parameters.query | "" | string |
-parameters.repeat_notifications | false | bool |
+field_content_value_parameters.grace | 0 | int |
+field_content_value_parameters.backlog | 0 | int |
+field_content_value_parameters.query | "" | string |
+field_content_value_parameters.repeat_notifications | false | bool |
 
 ## type: field_value 
 
@@ -62,19 +80,20 @@ parameters.repeat_notifications | false | bool |
 
 name | type | description
 --- | --- | ---
-parameters.field | string |
-parameters.type | string |
-parameters.threshold_type | string |
+field_value_parameters | object |
+field_value_parameters.field | string |
+field_value_parameters.type | string |
+field_value_parameters.threshold_type | string |
 
 ### Optional Argument
 
 name | default | type | description
 --- | --- | --- | ---
-parameters.grace | 0 | int |
-parameters.backlog | 0 | int |
-parameters.query | "" | string |
-parameters.threshold | 0 | int |
-parameters.time | 0 | int |
+field_value_parameters.grace | 0 | int |
+field_value_parameters.backlog | 0 | int |
+field_value_parameters.query | "" | string |
+field_value_parameters.threshold | 0 | int |
+field_value_parameters.time | 0 | int |
 
 ## type: message_count 
 
@@ -82,14 +101,38 @@ parameters.time | 0 | int |
 
 name | type | description
 --- | --- | ---
-parameters.threshold_type | string |
+message_count_parameters.threshold_type | string |
 
 ### Optional Argument
 
 name | default | type | description
 --- | --- | --- | ---
-parameters.grace | 0 | int |
-parameters.backlog | 0 | int |
-parameters.query | "" | string |
-parameters.threshold | 0 | int |
-parameters.time | 0 | int |
+message_count_parameters.grace | 0 | int |
+message_count_parameters.backlog | 0 | int |
+message_count_parameters.query | "" | string |
+message_count_parameters.threshold | 0 | int |
+message_count_parameters.time | 0 | int |
+
+## type: other third party's Alert Condition
+
+We support only the above alert condition types officially,
+but in order to support other alert condition types as much as possible,
+we provide some additional attributes.
+
+* `general_int_parameters`
+* `general_bool_parameters`
+* `general_float_parameters`
+* `general_string_parameters`
+
+### Required Argument
+
+None.
+
+### Optional Argument
+
+name | default | type | description
+--- | --- | --- | ---
+general_int_parameters | {} | map[string]int |
+general_bool_parameters | {} | map[string]bool |
+general_float_parameters | {} | map[string]float64 |
+general_string_parameters | {} | map[string]string |


### PR DESCRIPTION
Close #76

**BREAKING CHANGE**

* remove `parameters`
* instead of `parameters`, add the following fields
  * `field_content_value_parameters`
  * `field_value_parameters`
  * `message_count_parameters`
  * `general_int_parameters`
  * `general_bool_parameters`
  * `general_float_parameters`
  * `general_string_parameters`

## Migration Guide

In order to upgrade the terraform provider graylog, please update the terraform configuration file about the resource `graylog_alertcondition`.

If the alert condition type is `field_content_value`, rename the field `parameters` to `field_content_value_parameters`.
If the alert condition type is `field_value`, rename the field `parameters` to `field_value_parameters`.
If the alert condition type is `message_count`, rename the field `parameters` to `message_count_parameters`.