### PR TITLE
ci: fix release error

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -58,7 +58,7 @@ steps:
 - name: release
   image: suzukishunsuke/ghr
   commands:
-  - ghr -u suzuki-shunsuke ${DRONE_TAG} dist/${DRONE_TAG}
+  - ghr -u suzuki-shunsuke -r go-graylog ${DRONE_TAG} dist/${DRONE_TAG}
   environment:
     GITHUB_TOKEN:
       from_secret: github_token


### PR DESCRIPTION
Close #79

Probably it is failed to read .git/config to get repository name.
So we set the repository name explicitly by command line argument.