### PR TITLE
docs: fix the document of terraform-provider-graylog

### DIFF
--- a/terraform/docs/alarm_callback.md
+++ b/terraform/docs/alarm_callback.md
@@ -161,7 +161,7 @@ resource "graylog_alarm_callback" "hipchat" {
     room = "test"
   }
   general_bool_configuration = {
-    notify = true
+    notify = "true"
   }
 }
 ```

--- a/terraform/docs/alert_condition.md
+++ b/terraform/docs/alert_condition.md
@@ -7,15 +7,13 @@
 resource "graylog_alert_condition" "test-terraform" {
   type = "field_content_value"
   stream_id = "${graylog_stream.test-terraform.id}"
-  in_grace = false
   title = "test"
-  parameters = {
-    backlog = 1
-    repeat_notifications = false
+  field_content_value_parameters = {
     field = "message"
+    value = "hoge hoge"
+    backlog = 1
     query = "*"
     grace = 0
-    value = "hoge hoge"
   }
 }
 ```
@@ -45,13 +43,11 @@ in_grace | bool |
 resource "graylog_alert_condition" "test-terraform" {
   type = "field_content_value"
   stream_id = "${graylog_stream.test-terraform.id}"
-  in_grace = false
   title = "test"
   field_content_value_parameters = {
     field = "message"
     value = "hoge hoge"
     backlog = 1
-    repeat_notifications = false
     query = "*"
     grace = 0
   }

--- a/terraform/docs/dashboard_widget.md
+++ b/terraform/docs/dashboard_widget.md
@@ -12,8 +12,6 @@ resource "graylog_dashboard_widget" "test" {
       type = "relative"
       range = 300
     }
-    lower_is_better = true
-    trend = true
     stream_id = "5b3983000000000000000000"
     query = ""
   }
@@ -62,8 +60,6 @@ resource "graylog_dashboard_widget" "test" {
       type = "relative"
       range = 300
     }
-    lower_is_better = true
-    trend = true
     stream_id = "5b3983000000000000000000"
     query = ""
   }
@@ -102,8 +98,6 @@ resource "graylog_dashboard_widget" "test" {
     stream_id = "5b3983000000000000000000"
     query = ""
     field = "status"
-    show_data_table = true
-    show_pie_chart = true
     limit = 5
     sort_order = "desc"
     stacked_fields = ""
@@ -269,8 +263,6 @@ resource "graylog_dashboard_widget" "test" {
     }
     query = ""
     field = "status"
-    lower_is_better = false
-    trend = false
     stats_function = "cardinality"
     stream_id = "5b3983000000000000000000"
   }

--- a/terraform/docs/extractor.md
+++ b/terraform/docs/extractor.md
@@ -89,7 +89,6 @@ resource "graylog_extractor" "test" {
     kv_separator               = "="
     key_prefix                 = "visit_"
     key_separator              = "_"
-    replace_key_whitespace     = false
     key_whitespace_replacement = "_"
   }
 }

--- a/terraform/docs/ldap_setting.md
+++ b/terraform/docs/ldap_setting.md
@@ -4,13 +4,9 @@ https://github.com/suzuki-shunsuke/go-graylog/blob/master/terraform/graylog/reso
 
 ```hcl
 resource "graylog_ldap_setting" "foo" {
-  enabled = true
   system_username = "admin"
   system_password = "password"
   ldap_uri = "ldap://localhost:389"
-  use_start_tls = false
-  trust_all_certificates = false
-  active_directory = false
   search_base = "OU=user,OU=foo,DC=example,DC=com"
   search_pattern = "(cn={0})"
   display_name_attribute = "displayname"

--- a/terraform/docs/stream.md
+++ b/terraform/docs/stream.md
@@ -6,7 +6,6 @@ https://github.com/suzuki-shunsuke/go-graylog/blob/master/terraform/graylog/reso
 resource "graylog_stream" "test-terraform" {
   title = "test-terraform"
   index_set_id = "${graylog_index_set.test-terraform.id}"
-  disabled = true
   matching_type = "AND"
 }
 ```

--- a/terraform/docs/stream_rule.md
+++ b/terraform/docs/stream_rule.md
@@ -9,7 +9,6 @@ resource "graylog_stream_rule" "test-terraform" {
   stream_id = "${graylog_stream.test-terraform.id}"
   description = "test stream rule"
   type = 0
-  inverted = false
 }
 ```
 


### PR DESCRIPTION
remove boolean from examples because the treat of boolean in the Terraform configuration is ambiguous and it is out of the scope of this provider's document.
Whether we should embrace the boolean with quotes isn't the problem of terraform-provider-graylog but the problem of Terraform. I don't want to discuss it in this project.

https://github.com/suzuki-shunsuke/go-graylog/issues/127#issuecomment-509041353