### PR TITLE
feat: remove resource from state file if resource isn't found

### DIFF
--- a/.durl.yml
+++ b/.durl.yml
@@ -7,6 +7,7 @@ ignore_hosts:
 - graylog.example.com
 - hooks.slack.com
 - api.hipchat.com
+- goreportcard.com
 http_method: head,get
 max_request_count: 10
 max_failed_request_count: 5

--- a/terraform/graylog/resource_alarm_callback.go
+++ b/terraform/graylog/resource_alarm_callback.go
@@ -308,9 +308,9 @@ func resourceAlarmCallbackRead(d *schema.ResourceData, m interface{}) error {
 		return err
 	}
 	streamID := d.Get("stream_id").(string)
-	ac, _, err := cl.GetStreamAlarmCallback(ctx, streamID, d.Id())
+	ac, ei, err := cl.GetStreamAlarmCallback(ctx, streamID, d.Id())
 	if err != nil {
-		return err
+		return handleGetResourceError(d, ei, err)
 	}
 	if err := setStrToRD(d, "type", ac.Type()); err != nil {
 		return err

--- a/terraform/graylog/resource_alert_condition.go
+++ b/terraform/graylog/resource_alert_condition.go
@@ -433,9 +433,9 @@ func resourceAlertConditionRead(d *schema.ResourceData, m interface{}) error {
 		return err
 	}
 	streamID := d.Get("stream_id").(string)
-	cond, _, err := cl.GetStreamAlertCondition(ctx, streamID, d.Id())
+	cond, ei, err := cl.GetStreamAlertCondition(ctx, streamID, d.Id())
 	if err != nil {
-		return err
+		return handleGetResourceError(d, ei, err)
 	}
 	if err := setStrToRD(d, "type", cond.Type()); err != nil {
 		return err

--- a/terraform/graylog/resource_dashboard.go
+++ b/terraform/graylog/resource_dashboard.go
@@ -96,9 +96,9 @@ func resourceDashboardRead(d *schema.ResourceData, m interface{}) error {
 	if err != nil {
 		return err
 	}
-	db, _, err := cl.GetDashboard(ctx, d.Id())
+	db, ei, err := cl.GetDashboard(ctx, d.Id())
 	if err != nil {
-		return err
+		return handleGetResourceError(d, ei, err)
 	}
 	if err := setStrToRD(d, "title", db.Title); err != nil {
 		return err

--- a/terraform/graylog/resource_extractor.go
+++ b/terraform/graylog/resource_extractor.go
@@ -285,9 +285,9 @@ func resourceExtractorRead(d *schema.ResourceData, m interface{}) error {
 	if err != nil {
 		return err
 	}
-	extractor, _, err := cl.GetExtractor(ctx, d.Get("input_id").(string), d.Id())
+	extractor, ei, err := cl.GetExtractor(ctx, d.Get("input_id").(string), d.Id())
 	if err != nil {
-		return err
+		return handleGetResourceError(d, ei, err)
 	}
 	if err := setStrToRD(d, "title", extractor.Title); err != nil {
 		return err

--- a/terraform/graylog/resource_index_set.go
+++ b/terraform/graylog/resource_index_set.go
@@ -193,9 +193,9 @@ func resourceIndexSetRead(d *schema.ResourceData, m interface{}) error {
 	if err != nil {
 		return err
 	}
-	is, _, err := cl.GetIndexSet(ctx, d.Id())
+	is, ei, err := cl.GetIndexSet(ctx, d.Id())
 	if err != nil {
-		return err
+		return handleGetResourceError(d, ei, err)
 	}
 	return setIndexSet(d, is, cfg)
 }

--- a/terraform/graylog/resource_input.go
+++ b/terraform/graylog/resource_input.go
@@ -145,11 +145,7 @@ func resourceInputRead(d *schema.ResourceData, m interface{}) error {
 	}
 	input, ei, err := cl.GetInput(ctx, d.Id())
 	if err != nil {
-		if ei != nil && ei.Response != nil && ei.Response.StatusCode == 404 {
-			d.SetId("")
-			return nil
-		}
-		return err
+		return handleGetResourceError(d, ei, err)
 	}
 	if input.Attrs != nil {
 		b, err := json.Marshal(input.Attrs)

--- a/terraform/graylog/resource_pipeline.go
+++ b/terraform/graylog/resource_pipeline.go
@@ -70,9 +70,9 @@ func resourcePipelineRead(d *schema.ResourceData, m interface{}) error {
 	if err != nil {
 		return err
 	}
-	pipe, _, err := cl.GetPipeline(ctx, d.Id())
+	pipe, ei, err := cl.GetPipeline(ctx, d.Id())
 	if err != nil {
-		return err
+		return handleGetResourceError(d, ei, err)
 	}
 	if err := setStrToRD(d, "source", pipe.Source); err != nil {
 		return err

--- a/terraform/graylog/resource_pipeline_rule.go
+++ b/terraform/graylog/resource_pipeline_rule.go
@@ -69,9 +69,9 @@ func resourcePipelineRuleRead(d *schema.ResourceData, m interface{}) error {
 	if err != nil {
 		return err
 	}
-	rule, _, err := cl.GetPipelineRule(ctx, d.Id())
+	rule, ei, err := cl.GetPipelineRule(ctx, d.Id())
 	if err != nil {
-		return err
+		return handleGetResourceError(d, ei, err)
 	}
 	if err := setStrToRD(d, "source", rule.Source); err != nil {
 		return err

--- a/terraform/graylog/resource_role.go
+++ b/terraform/graylog/resource_role.go
@@ -72,9 +72,9 @@ func resourceRoleRead(d *schema.ResourceData, m interface{}) error {
 	if err != nil {
 		return err
 	}
-	role, _, err := cl.GetRole(ctx, d.Id())
+	role, ei, err := cl.GetRole(ctx, d.Id())
 	if err != nil {
-		return err
+		return handleGetResourceError(d, ei, err)
 	}
 	if err := setStrToRD(d, "name", role.Name); err != nil {
 		return err

--- a/terraform/graylog/resource_stream.go
+++ b/terraform/graylog/resource_stream.go
@@ -115,9 +115,9 @@ func resourceStreamRead(d *schema.ResourceData, m interface{}) error {
 	if err != nil {
 		return err
 	}
-	stream, _, err := cl.GetStream(ctx, d.Id())
+	stream, ei, err := cl.GetStream(ctx, d.Id())
 	if err != nil {
-		return err
+		return handleGetResourceError(d, ei, err)
 	}
 	return setStream(d, stream, m.(*Config))
 

--- a/terraform/graylog/resource_stream_rule.go
+++ b/terraform/graylog/resource_stream_rule.go
@@ -88,9 +88,9 @@ func resourceStreamRuleRead(d *schema.ResourceData, m interface{}) error {
 	if err != nil {
 		return err
 	}
-	rule, _, err := cl.GetStreamRule(ctx, d.Get("stream_id").(string), d.Id())
+	rule, ei, err := cl.GetStreamRule(ctx, d.Get("stream_id").(string), d.Id())
 	if err != nil {
-		return err
+		return handleGetResourceError(d, ei, err)
 	}
 	if err := setStrToRD(d, "field", rule.Field); err != nil {
 		return err

--- a/terraform/graylog/resource_user.go
+++ b/terraform/graylog/resource_user.go
@@ -142,9 +142,9 @@ func resourceUserRead(d *schema.ResourceData, m interface{}) error {
 	if err != nil {
 		return err
 	}
-	user, _, err := cl.GetUser(ctx, d.Id())
+	user, ei, err := cl.GetUser(ctx, d.Id())
 	if err != nil {
-		return err
+		return handleGetResourceError(d, ei, err)
 	}
 	if err := setStrToRD(d, "username", user.Username); err != nil {
 		return err

--- a/terraform/graylog/util.go
+++ b/terraform/graylog/util.go
@@ -29,6 +29,16 @@ func genImport(keys ...string) schema.StateFunc {
 	}
 }
 
+func handleGetResourceError(
+	d *schema.ResourceData, ei *client.ErrorInfo, err error,
+) error {
+	if ei != nil && ei.Response != nil && ei.Response.StatusCode == 404 {
+		d.SetId("")
+		return nil
+	}
+	return err
+}
+
 func getStringArray(src []interface{}) []string {
 	dest := make([]string, len(src))
 	for i, p := range src {


### PR DESCRIPTION
issue: #154

BREAKING CHANGE: remove the resource from the Terraform state file if it is failed to get the resource by refresh

AS-IS: Raise an error if it is failed to get the resource by `terraform refresh`

TO-BE: if it is failed to get the resource by `terraform refresh` and
the response status code is 404, remove the resource from Terraform state file