### PR TITLE
closes #192 update import path to v8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/suzuki-shunsuke/go-graylog
+module github.com/suzuki-shunsuke/go-graylog/v8
 
 go 1.13
 


### PR DESCRIPTION
module contains a go.mod file, so semantic import versioning is required