### PR TITLE
[WIP] feat: semantic import versioning

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -14,7 +14,7 @@ volumes:
   temp: {}
 steps:
 - name: download go modules
-  image: &image_go golang:1.13.3
+  image: &image_go golang:1.13.4
   commands:
   - go mod download
   volumes: &volumes
@@ -23,7 +23,7 @@ steps:
   environment:
     GOPATH: /go
 - name: golangci-lint
-  image: golangci/golangci-lint:v1.21.0
+  image: golangci/golangci-lint:v1.21.0-alpine
   commands:
   - golangci-lint run
   volumes: *volumes
@@ -51,7 +51,7 @@ steps:
     event:
     - tag
 - name: release
-  image: &goreleaser goreleaser/goreleaser:v0.119.0
+  image: &goreleaser goreleaser/goreleaser:v0.123.3
   commands:
   - goreleaser release
   environment:

--- a/client/alarm_callback.go
+++ b/client/alarm_callback.go
@@ -3,7 +3,7 @@ package client
 import (
 	"context"
 
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 )
 
 // GetAlarmCallbacksContext returns all alarm callbacks.

--- a/client/alarm_callback_test.go
+++ b/client/alarm_callback_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/suzuki-shunsuke/go-graylog/testutil"
+	"github.com/suzuki-shunsuke/go-graylog/testutil/v8"
 )
 
 func TestClient_GetAlarmCallbacks(t *testing.T) {

--- a/client/alert.go
+++ b/client/alert.go
@@ -6,7 +6,7 @@ import (
 	"net/url"
 	"strconv"
 
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 )
 
 // GetAlert returns an alert.

--- a/client/alert_condition.go
+++ b/client/alert_condition.go
@@ -3,7 +3,7 @@ package client
 import (
 	"context"
 
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 )
 
 // GetAlertConditions returns all alert conditions.

--- a/client/alert_condition_test.go
+++ b/client/alert_condition_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/suzuki-shunsuke/go-graylog/testutil"
+	"github.com/suzuki-shunsuke/go-graylog/testutil/v8"
 )
 
 func TestClient_GetAlertConditions(t *testing.T) {

--- a/client/alert_test.go
+++ b/client/alert_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/suzuki-shunsuke/go-graylog/testutil"
+	"github.com/suzuki-shunsuke/go-graylog/testutil/v8"
 )
 
 func TestClient_GetAlerts(t *testing.T) {

--- a/client/client.go
+++ b/client/client.go
@@ -3,7 +3,7 @@ package client
 import (
 	"net/http"
 
-	"github.com/suzuki-shunsuke/go-graylog/client/endpoint"
+	"github.com/suzuki-shunsuke/go-graylog/client/endpoint/v8"
 )
 
 // Client represents a Graylog API client.

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -3,7 +3,7 @@ package client_test
 import (
 	"testing"
 
-	"github.com/suzuki-shunsuke/go-graylog/client"
+	"github.com/suzuki-shunsuke/go-graylog/client/v8"
 )
 
 const (

--- a/client/collector_configuration.go
+++ b/client/collector_configuration.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/suzuki-shunsuke/go-set"
 
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 )
 
 // CreateCollectorConfiguration creates a collector configuration.

--- a/client/collector_configuration_input.go
+++ b/client/collector_configuration_input.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 )
 
 // CreateCollectorConfigurationInput creates a collector configuration input.

--- a/client/collector_configuration_output.go
+++ b/client/collector_configuration_output.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 )
 
 // CreateCollectorConfigurationOutput creates a collector configuration output.

--- a/client/collector_configuration_snippet.go
+++ b/client/collector_configuration_snippet.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 )
 
 // CreateCollectorConfigurationSnippet creates a collector configuration snippet.

--- a/client/dashboard.go
+++ b/client/dashboard.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 )
 
 // CreateDashboard creates a new dashboard account.

--- a/client/dashboard_test.go
+++ b/client/dashboard_test.go
@@ -9,10 +9,10 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/suzuki-shunsuke/flute/flute"
 
-	"github.com/suzuki-shunsuke/go-graylog"
-	"github.com/suzuki-shunsuke/go-graylog/client"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
+	"github.com/suzuki-shunsuke/go-graylog/client/v8"
 	"github.com/suzuki-shunsuke/go-graylog/testdata"
-	"github.com/suzuki-shunsuke/go-graylog/testutil"
+	"github.com/suzuki-shunsuke/go-graylog/testutil/v8"
 )
 
 func TestClient_CreateDashboard(t *testing.T) {

--- a/client/dashboard_widget.go
+++ b/client/dashboard_widget.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 )
 
 // CreateDashboardWidget creates a new dashboard widget.

--- a/client/dashboard_widget_test.go
+++ b/client/dashboard_widget_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/suzuki-shunsuke/go-jsoneq/jsoneq"
 	"github.com/suzuki-shunsuke/go-ptr"
 
-	"github.com/suzuki-shunsuke/go-graylog"
-	"github.com/suzuki-shunsuke/go-graylog/client"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
+	"github.com/suzuki-shunsuke/go-graylog/client/v8"
 )
 
 func TestClient_CreateDashboardWidget(t *testing.T) {

--- a/client/endpoint/alarm_callback_test.go
+++ b/client/endpoint/alarm_callback_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/suzuki-shunsuke/go-graylog/client/endpoint"
+	"github.com/suzuki-shunsuke/go-graylog/client/endpoint/v8"
 )
 
 func TestEndpoints_AlarmCallbacks(t *testing.T) {

--- a/client/endpoint/alert_condition_test.go
+++ b/client/endpoint/alert_condition_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/suzuki-shunsuke/go-graylog/client/endpoint"
+	"github.com/suzuki-shunsuke/go-graylog/client/endpoint/v8"
 )
 
 func TestEndpoints_AlertConditions(t *testing.T) {

--- a/client/endpoint/alert_test.go
+++ b/client/endpoint/alert_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/suzuki-shunsuke/go-graylog/client/endpoint"
+	"github.com/suzuki-shunsuke/go-graylog/client/endpoint/v8"
 )
 
 func TestEndpoints_Alerts(t *testing.T) {

--- a/client/endpoint/dashboard_test.go
+++ b/client/endpoint/dashboard_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/suzuki-shunsuke/go-graylog/client/endpoint"
+	"github.com/suzuki-shunsuke/go-graylog/client/endpoint/v8"
 )
 
 func TestEndpoints_Dashboards(t *testing.T) {

--- a/client/endpoint/endpoint_test.go
+++ b/client/endpoint/endpoint_test.go
@@ -3,7 +3,7 @@ package endpoint_test
 import (
 	"testing"
 
-	"github.com/suzuki-shunsuke/go-graylog/client/endpoint"
+	"github.com/suzuki-shunsuke/go-graylog/client/endpoint/v8"
 )
 
 const (

--- a/client/endpoint/index_set_test.go
+++ b/client/endpoint/index_set_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/suzuki-shunsuke/go-graylog/client/endpoint"
+	"github.com/suzuki-shunsuke/go-graylog/client/endpoint/v8"
 )
 
 func TestEndpoints_IndexSets(t *testing.T) {

--- a/client/endpoint/input_test.go
+++ b/client/endpoint/input_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/suzuki-shunsuke/go-graylog/client/endpoint"
+	"github.com/suzuki-shunsuke/go-graylog/client/endpoint/v8"
 )
 
 func TestEndpoints_Inputs(t *testing.T) {

--- a/client/endpoint/role_test.go
+++ b/client/endpoint/role_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/suzuki-shunsuke/go-graylog/client/endpoint"
+	"github.com/suzuki-shunsuke/go-graylog/client/endpoint/v8"
 )
 
 func TestEndpoints_Roles(t *testing.T) {

--- a/client/endpoint/stream_rule_test.go
+++ b/client/endpoint/stream_rule_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/suzuki-shunsuke/go-graylog/client/endpoint"
+	"github.com/suzuki-shunsuke/go-graylog/client/endpoint/v8"
 )
 
 func TestEndpoints_StreamRules(t *testing.T) {

--- a/client/endpoint/stream_test.go
+++ b/client/endpoint/stream_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/suzuki-shunsuke/go-graylog/client/endpoint"
+	"github.com/suzuki-shunsuke/go-graylog/client/endpoint/v8"
 )
 
 func TestEndpoints_Streams(t *testing.T) {

--- a/client/endpoint/user_test.go
+++ b/client/endpoint/user_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/suzuki-shunsuke/go-graylog/client/endpoint"
+	"github.com/suzuki-shunsuke/go-graylog/client/endpoint/v8"
 )
 
 func TestEndpoints_Users(t *testing.T) {

--- a/client/example_test.go
+++ b/client/example_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/suzuki-shunsuke/go-graylog/client"
+	"github.com/suzuki-shunsuke/go-graylog/client/v8"
 	"github.com/suzuki-shunsuke/graylog-mock-server/mockserver"
 )
 

--- a/client/extractor.go
+++ b/client/extractor.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 )
 
 // GetExtractors returns all extractors.

--- a/client/extractor_test.go
+++ b/client/extractor_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/suzuki-shunsuke/go-jsoneq/jsoneq"
 
-	"github.com/suzuki-shunsuke/go-graylog"
-	"github.com/suzuki-shunsuke/go-graylog/client"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
+	"github.com/suzuki-shunsuke/go-graylog/client/v8"
 )
 
 func sampleExtractor1() *graylog.Extractor {

--- a/client/grok_pattern.go
+++ b/client/grok_pattern.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 )
 
 // CreateGrokPattern creates a new grok pattern.

--- a/client/grok_pattern_test.go
+++ b/client/grok_pattern_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/suzuki-shunsuke/flute/flute"
 
-	"github.com/suzuki-shunsuke/go-graylog"
-	"github.com/suzuki-shunsuke/go-graylog/client"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
+	"github.com/suzuki-shunsuke/go-graylog/client/v8"
 )
 
 const (

--- a/client/index_set.go
+++ b/client/index_set.go
@@ -6,7 +6,7 @@ import (
 	"net/url"
 	"strconv"
 
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 )
 
 // GetIndexSets returns a list of all index sets.

--- a/client/index_set_stats.go
+++ b/client/index_set_stats.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 )
 
 // GetIndexSetStats returns a given Index Set statistics.

--- a/client/index_set_stats_test.go
+++ b/client/index_set_stats_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/gofrs/uuid"
-	"github.com/suzuki-shunsuke/go-graylog/testutil"
+	"github.com/suzuki-shunsuke/go-graylog/testutil/v8"
 )
 
 func TestClient_GetIndexSetStats(t *testing.T) {

--- a/client/index_set_test.go
+++ b/client/index_set_test.go
@@ -11,10 +11,10 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/suzuki-shunsuke/flute/flute"
 
-	"github.com/suzuki-shunsuke/go-graylog"
-	"github.com/suzuki-shunsuke/go-graylog/client"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
+	"github.com/suzuki-shunsuke/go-graylog/client/v8"
 	"github.com/suzuki-shunsuke/go-graylog/testdata"
-	"github.com/suzuki-shunsuke/go-graylog/testutil"
+	"github.com/suzuki-shunsuke/go-graylog/testutil/v8"
 	"github.com/suzuki-shunsuke/go-ptr"
 )
 

--- a/client/input.go
+++ b/client/input.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 )
 
 // GetInputs returns all inputs.

--- a/client/input_test.go
+++ b/client/input_test.go
@@ -9,10 +9,10 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/suzuki-shunsuke/flute/flute"
 
-	"github.com/suzuki-shunsuke/go-graylog"
-	"github.com/suzuki-shunsuke/go-graylog/client"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
+	"github.com/suzuki-shunsuke/go-graylog/client/v8"
 	"github.com/suzuki-shunsuke/go-graylog/testdata"
-	"github.com/suzuki-shunsuke/go-graylog/testutil"
+	"github.com/suzuki-shunsuke/go-graylog/testutil/v8"
 )
 
 func TestClient_GetInputs(t *testing.T) {

--- a/client/ldap_group_test.go
+++ b/client/ldap_group_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/suzuki-shunsuke/go-graylog/client"
+	"github.com/suzuki-shunsuke/go-graylog/client/v8"
 )
 
 func TestClient_GetLDAPGroups(t *testing.T) {

--- a/client/ldap_setting.go
+++ b/client/ldap_setting.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 )
 
 // GetLDAPSetting returns the LDAP setting.

--- a/client/ldap_setting_test.go
+++ b/client/ldap_setting_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/suzuki-shunsuke/go-set"
 
-	"github.com/suzuki-shunsuke/go-graylog"
-	"github.com/suzuki-shunsuke/go-graylog/client"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
+	"github.com/suzuki-shunsuke/go-graylog/client/v8"
 )
 
 func TestClient_GetLDAPSetting(t *testing.T) {

--- a/client/pipeline.go
+++ b/client/pipeline.go
@@ -3,7 +3,7 @@ package client
 import (
 	"context"
 
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 )
 
 // GetPipelines returns all pipeline.

--- a/client/pipeline_connection.go
+++ b/client/pipeline_connection.go
@@ -3,7 +3,7 @@ package client
 import (
 	"context"
 
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 )
 
 // GetPipelineConnections returns all pipeline connections.

--- a/client/pipeline_rule.go
+++ b/client/pipeline_rule.go
@@ -3,7 +3,7 @@ package client
 import (
 	"context"
 
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 )
 
 // GetPipelineRules returns all pipeline rules.

--- a/client/pipeline_rule_test.go
+++ b/client/pipeline_rule_test.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/suzuki-shunsuke/go-graylog"
-	"github.com/suzuki-shunsuke/go-graylog/client"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
+	"github.com/suzuki-shunsuke/go-graylog/client/v8"
 )
 
 func TestClient_GetPipelineRules(t *testing.T) {

--- a/client/pipeline_test.go
+++ b/client/pipeline_test.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/suzuki-shunsuke/go-graylog"
-	"github.com/suzuki-shunsuke/go-graylog/client"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
+	"github.com/suzuki-shunsuke/go-graylog/client/v8"
 )
 
 func TestClient_GetPipelines(t *testing.T) {

--- a/client/role.go
+++ b/client/role.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 )
 
 // CreateRole creates a new role.

--- a/client/role_member.go
+++ b/client/role_member.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 )
 
 // GetRoleMembers returns a given role's members.

--- a/client/role_member_test.go
+++ b/client/role_member_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/suzuki-shunsuke/go-graylog/testutil"
+	"github.com/suzuki-shunsuke/go-graylog/testutil/v8"
 )
 
 func TestClient_GetRoleMembers(t *testing.T) {

--- a/client/role_test.go
+++ b/client/role_test.go
@@ -9,9 +9,9 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/suzuki-shunsuke/flute/flute"
 
-	"github.com/suzuki-shunsuke/go-graylog/client"
+	"github.com/suzuki-shunsuke/go-graylog/client/v8"
 	"github.com/suzuki-shunsuke/go-graylog/testdata"
-	"github.com/suzuki-shunsuke/go-graylog/testutil"
+	"github.com/suzuki-shunsuke/go-graylog/testutil/v8"
 )
 
 func TestClient_CreateRole(t *testing.T) {

--- a/client/stream.go
+++ b/client/stream.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 )
 
 // GetStreams returns all streams.

--- a/client/stream_alarm_callback.go
+++ b/client/stream_alarm_callback.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 )
 
 // GetStreamAlarmCallbacks gets all alarm callbacks of this stream.

--- a/client/stream_alarm_callback_test.go
+++ b/client/stream_alarm_callback_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/suzuki-shunsuke/flute/flute"
 	"github.com/suzuki-shunsuke/go-set"
 
-	"github.com/suzuki-shunsuke/go-graylog"
-	"github.com/suzuki-shunsuke/go-graylog/client"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
+	"github.com/suzuki-shunsuke/go-graylog/client/v8"
 	"github.com/suzuki-shunsuke/go-graylog/testdata"
 )
 

--- a/client/stream_alert_condition.go
+++ b/client/stream_alert_condition.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 )
 
 // GetStreamAlertConditions gets all alert conditions of this stream.

--- a/client/stream_alert_condition_test.go
+++ b/client/stream_alert_condition_test.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/suzuki-shunsuke/go-graylog"
-	"github.com/suzuki-shunsuke/go-graylog/client"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
+	"github.com/suzuki-shunsuke/go-graylog/client/v8"
 )
 
 func TestClient_GetStreamAlertConditions(t *testing.T) {

--- a/client/stream_rule.go
+++ b/client/stream_rule.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 )
 
 // GetStreamRuleTypes returns all available stream types

--- a/client/stream_rule_test.go
+++ b/client/stream_rule_test.go
@@ -9,10 +9,10 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/suzuki-shunsuke/flute/flute"
 
-	"github.com/suzuki-shunsuke/go-graylog"
-	"github.com/suzuki-shunsuke/go-graylog/client"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
+	"github.com/suzuki-shunsuke/go-graylog/client/v8"
 	"github.com/suzuki-shunsuke/go-graylog/testdata"
-	"github.com/suzuki-shunsuke/go-graylog/testutil"
+	"github.com/suzuki-shunsuke/go-graylog/testutil/v8"
 )
 
 func TestClient_GetStreamRules(t *testing.T) {

--- a/client/stream_test.go
+++ b/client/stream_test.go
@@ -11,9 +11,9 @@ import (
 
 	"github.com/gofrs/uuid"
 
-	"github.com/suzuki-shunsuke/go-graylog/client"
+	"github.com/suzuki-shunsuke/go-graylog/client/v8"
 	"github.com/suzuki-shunsuke/go-graylog/testdata"
-	"github.com/suzuki-shunsuke/go-graylog/testutil"
+	"github.com/suzuki-shunsuke/go-graylog/testutil/v8"
 )
 
 func TestClient_GetStreams(t *testing.T) {

--- a/client/user.go
+++ b/client/user.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 )
 
 // CreateUser creates a new user account.

--- a/client/user_test.go
+++ b/client/user_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/suzuki-shunsuke/flute/flute"
 	"github.com/suzuki-shunsuke/go-set"
 
-	"github.com/suzuki-shunsuke/go-graylog"
-	"github.com/suzuki-shunsuke/go-graylog/client"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
+	"github.com/suzuki-shunsuke/go-graylog/client/v8"
 	"github.com/suzuki-shunsuke/go-graylog/testdata"
 )
 

--- a/cmd/generate-testdata/main.go
+++ b/cmd/generate-testdata/main.go
@@ -16,7 +16,7 @@ import (
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/sanity-io/litter"
 
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 )
 
 type (

--- a/extractor_test.go
+++ b/extractor_test.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 )
 
 func TestExtractor_MarshalJSON(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/suzuki-shunsuke/go-graylog
+module github.com/suzuki-shunsuke/go-graylog/v8
 
 go 1.13
 

--- a/go.sum
+++ b/go.sum
@@ -8,7 +8,6 @@ dmitri.shuralyov.com/html/belt v0.0.0-20180602232347-f7d459c86be0/go.mod h1:JLBr
 dmitri.shuralyov.com/service/change v0.0.0-20181023043359-a85b471d5412/go.mod h1:a1inKt/atXimZ4Mv927x+r7UpyzRUf4emIoiiSC2TN4=
 dmitri.shuralyov.com/state v0.0.0-20180228185332-28bcc343414c/go.mod h1:0PRwlb0D6DFvNNtx+9ybjezNCa8XF0xaYcETyp6rHWU=
 git.apache.org/thrift.git v0.0.0-20180902110319-2566ecd5d999/go.mod h1:fPE2ZNJGynbRyZ4dJvy6G277gSllfV2HJqblrnkyeyg=
-github.com/AlecAivazis/survey v1.8.7 h1:QIBq36/0wfYpXxdBqDXNAjKHx1bKnRGu/EDnva27k84=
 github.com/AlecAivazis/survey/v2 v2.0.4 h1:qzXnJSzXEvmUllWqMBWpZndvT2YfoAUzAMvZUax3L2M=
 github.com/AlecAivazis/survey/v2 v2.0.4/go.mod h1:WYBhg6f0y/fNYUuesWQc0PKbJcEliGcYHB9sNT3Bg74=
 github.com/Azure/azure-sdk-for-go v21.3.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
@@ -362,6 +361,7 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/suzuki-shunsuke/flute v0.7.0 h1:DvDSCMIMiLlRj4AQPMeJ1NfHE3lG5yfs2LU0Dnf1+oc=
 github.com/suzuki-shunsuke/flute v0.7.0/go.mod h1:UZOMr3GyEuYSr7/zf0nHgaLP9ZhKDB+2pBeV1WFkohE=
 github.com/suzuki-shunsuke/go-cliutil v0.0.0-20181211154308-176f852d9bca/go.mod h1:Vq3NkhgmA9DT/2UZ08x/3A34xxvzQ/vTMABnTWKoMbY=
+github.com/suzuki-shunsuke/go-graylog v2.5.0+incompatible h1:6G5hjnyxyLjc1GGksED+wcbQSTNmVzVhkthhVll6HyY=
 github.com/suzuki-shunsuke/go-graylog v2.5.0+incompatible/go.mod h1:+z9FAnkMp+N5llMe0nxwlYSvf6bep5zgB/0q2QEl9oQ=
 github.com/suzuki-shunsuke/go-jsoneq v0.1.1 h1:A9ik3qCfjjR2zbOTHwOIIt+N4ItZGZq9j8z//t5EhnQ=
 github.com/suzuki-shunsuke/go-jsoneq v0.1.1/go.mod h1:vbOEb6bPf8nD+QASKzxtQ/vfVGgAyfWHyItUaUTwJWk=
@@ -369,7 +369,6 @@ github.com/suzuki-shunsuke/go-ptr v1.0.0 h1:sVR6ICMJbdCyOpxzrflHErkO8KmItPFDu0E0
 github.com/suzuki-shunsuke/go-ptr v1.0.0/go.mod h1:4WKv+CJynv3Veutqvmt7yPUqEsZp0vezqFxVRukjga0=
 github.com/suzuki-shunsuke/go-set v6.0.0+incompatible h1:APxAhd/XeHGrrp3vR6a9Yiwgak+HlM+CVREvDAULM8w=
 github.com/suzuki-shunsuke/go-set v6.0.0+incompatible/go.mod h1:CZob7MsjSLZlWDHWKeRvDX/Q2eWA6qqbx+FXdy2FgnM=
-github.com/suzuki-shunsuke/gomic v0.5.6 h1:CESWNVStuOedtx7s7JwhvFdy8CxuoyZJ8LcKvtbFMa8=
 github.com/suzuki-shunsuke/gomic v0.5.6/go.mod h1:GEDQnxOB07p3mTZG/MiuclfyfcqnNqp0rt9AHgIzs7Q=
 github.com/suzuki-shunsuke/graylog-mock-server v1.0.0 h1:kvVQfNoZhl8TkDE3mqrk1GlYDoY46IcanuLaSTLGvBw=
 github.com/suzuki-shunsuke/graylog-mock-server v1.0.0/go.mod h1:7uVmBcYbjffvfThyQ6q1cbXNm/VvogFyjnoiuFywgv4=

--- a/index_set_test.go
+++ b/index_set_test.go
@@ -3,8 +3,8 @@ package graylog_test
 import (
 	"testing"
 
-	"github.com/suzuki-shunsuke/go-graylog"
-	"github.com/suzuki-shunsuke/go-graylog/testutil"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
+	"github.com/suzuki-shunsuke/go-graylog/testutil/v8"
 )
 
 func TestIndexSetNewUpdateParams(t *testing.T) {

--- a/input.go
+++ b/input.go
@@ -3,7 +3,7 @@ package graylog
 import (
 	"encoding/json"
 
-	"github.com/suzuki-shunsuke/go-graylog/util"
+	"github.com/suzuki-shunsuke/go-graylog/util/v8"
 	"github.com/suzuki-shunsuke/go-ptr"
 )
 

--- a/input_attrs_test.go
+++ b/input_attrs_test.go
@@ -3,7 +3,7 @@ package graylog_test
 import (
 	"testing"
 
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 )
 
 func TestNewInputAttrsByType(t *testing.T) {

--- a/input_data.go
+++ b/input_data.go
@@ -3,7 +3,7 @@ package graylog
 import (
 	"fmt"
 
-	"github.com/suzuki-shunsuke/go-graylog/util"
+	"github.com/suzuki-shunsuke/go-graylog/util/v8"
 )
 
 type (

--- a/input_data_test.go
+++ b/input_data_test.go
@@ -3,7 +3,7 @@ package graylog_test
 import (
 	"testing"
 
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 )
 
 func TestInputUpdatePramsDataToInputUpdateParams(t *testing.T) {

--- a/input_test.go
+++ b/input_test.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/suzuki-shunsuke/go-graylog"
-	"github.com/suzuki-shunsuke/go-graylog/testutil"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
+	"github.com/suzuki-shunsuke/go-graylog/testutil/v8"
 )
 
 func TestInputUnmarshalJSON(t *testing.T) {

--- a/role_test.go
+++ b/role_test.go
@@ -3,7 +3,7 @@ package graylog_test
 import (
 	"testing"
 
-	"github.com/suzuki-shunsuke/go-graylog/testutil"
+	"github.com/suzuki-shunsuke/go-graylog/testutil/v8"
 )
 
 func TestRoleNewUpdateParams(t *testing.T) {

--- a/stream_rule_test.go
+++ b/stream_rule_test.go
@@ -3,7 +3,7 @@ package graylog_test
 import (
 	"testing"
 
-	"github.com/suzuki-shunsuke/go-graylog/testutil"
+	"github.com/suzuki-shunsuke/go-graylog/testutil/v8"
 )
 
 func TestStreamRuleNewUpdateParams(t *testing.T) {

--- a/stream_test.go
+++ b/stream_test.go
@@ -3,7 +3,7 @@ package graylog_test
 import (
 	"testing"
 
-	"github.com/suzuki-shunsuke/go-graylog/testutil"
+	"github.com/suzuki-shunsuke/go-graylog/testutil/v8"
 )
 
 func TestStreamNewUpdateParams(t *testing.T) {

--- a/terraform/graylog/data_source_dashboard.go
+++ b/terraform/graylog/data_source_dashboard.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/schema"
 
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 )
 
 func dataSourceDashboard() *schema.Resource {

--- a/terraform/graylog/data_source_index_set.go
+++ b/terraform/graylog/data_source_index_set.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/schema"
 
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 )
 
 func dataSourceIndexSet() *schema.Resource {

--- a/terraform/graylog/data_source_stream.go
+++ b/terraform/graylog/data_source_stream.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/schema"
 
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 )
 
 func dataSourceStream() *schema.Resource {

--- a/terraform/graylog/resource_alarm_callback.go
+++ b/terraform/graylog/resource_alarm_callback.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/suzuki-shunsuke/go-set"
 
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 )
 
 func resourceAlarmCallback() *schema.Resource {

--- a/terraform/graylog/resource_alert_condition.go
+++ b/terraform/graylog/resource_alert_condition.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 )
 
 func resourceAlertCondition() *schema.Resource {

--- a/terraform/graylog/resource_dashboard.go
+++ b/terraform/graylog/resource_dashboard.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/schema"
 
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 )
 
 func resourceDashboard() *schema.Resource {

--- a/terraform/graylog/resource_dashboard_test.go
+++ b/terraform/graylog/resource_dashboard_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 
-	"github.com/suzuki-shunsuke/go-graylog/client"
+	"github.com/suzuki-shunsuke/go-graylog/client/v8"
 )
 
 func testDeleteDashboard(

--- a/terraform/graylog/resource_dashboard_widget.go
+++ b/terraform/graylog/resource_dashboard_widget.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/schema"
 
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 	"github.com/suzuki-shunsuke/go-ptr"
 )
 

--- a/terraform/graylog/resource_dashboard_widget_positions.go
+++ b/terraform/graylog/resource_dashboard_widget_positions.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/schema"
 
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 )
 
 func resourceDashboardWidgetPositions() *schema.Resource {

--- a/terraform/graylog/resource_extractor.go
+++ b/terraform/graylog/resource_extractor.go
@@ -8,7 +8,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/suzuki-shunsuke/go-jsoneq/jsoneq"
 
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 )
 
 func resourceExtractor() *schema.Resource {

--- a/terraform/graylog/resource_grok_pattern.go
+++ b/terraform/graylog/resource_grok_pattern.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/schema"
 
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 )
 
 func resourceGrokPattern() *schema.Resource {

--- a/terraform/graylog/resource_index_set.go
+++ b/terraform/graylog/resource_index_set.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/hashicorp/terraform/helper/schema"
 
-	"github.com/suzuki-shunsuke/go-graylog"
-	"github.com/suzuki-shunsuke/go-graylog/util"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
+	"github.com/suzuki-shunsuke/go-graylog/util/v8"
 )
 
 func resourceIndexSet() *schema.Resource {

--- a/terraform/graylog/resource_index_set_test.go
+++ b/terraform/graylog/resource_index_set_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 
-	"github.com/suzuki-shunsuke/go-graylog/client"
-	"github.com/suzuki-shunsuke/go-graylog/testutil"
+	"github.com/suzuki-shunsuke/go-graylog/client/v8"
+	"github.com/suzuki-shunsuke/go-graylog/testutil/v8"
 	"github.com/suzuki-shunsuke/graylog-mock-server/mockserver"
 )
 

--- a/terraform/graylog/resource_input.go
+++ b/terraform/graylog/resource_input.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/schema"
 
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 )
 
 func resourceInput() *schema.Resource {

--- a/terraform/graylog/resource_input_test.go
+++ b/terraform/graylog/resource_input_test.go
@@ -8,7 +8,7 @@ package graylog
 // 	"github.com/hashicorp/terraform/helper/resource"
 // 	"github.com/hashicorp/terraform/terraform"
 //
-// 	"github.com/suzuki-shunsuke/go-graylog/client"
+// 	"github.com/suzuki-shunsuke/go-graylog/client/v8"
 // )
 //
 // var (

--- a/terraform/graylog/resource_ldap_setting.go
+++ b/terraform/graylog/resource_ldap_setting.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/suzuki-shunsuke/go-set"
 
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 )
 
 const (

--- a/terraform/graylog/resource_ldap_setting_test.go
+++ b/terraform/graylog/resource_ldap_setting_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 
-	"github.com/suzuki-shunsuke/go-graylog/client"
+	"github.com/suzuki-shunsuke/go-graylog/client/v8"
 )
 
 func testDeleteLDAPSetting(

--- a/terraform/graylog/resource_pipeline.go
+++ b/terraform/graylog/resource_pipeline.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/schema"
 
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 )
 
 func resourcePipeline() *schema.Resource {

--- a/terraform/graylog/resource_pipeline_connection.go
+++ b/terraform/graylog/resource_pipeline_connection.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/schema"
 
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 )
 
 func resourcePipelineConnection() *schema.Resource {

--- a/terraform/graylog/resource_pipeline_rule.go
+++ b/terraform/graylog/resource_pipeline_rule.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/schema"
 
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 )
 
 func resourcePipelineRule() *schema.Resource {

--- a/terraform/graylog/resource_role.go
+++ b/terraform/graylog/resource_role.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/suzuki-shunsuke/go-set"
 
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 )
 
 func resourceRole() *schema.Resource {

--- a/terraform/graylog/resource_role_test.go
+++ b/terraform/graylog/resource_role_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 
-	"github.com/suzuki-shunsuke/go-graylog/client"
+	"github.com/suzuki-shunsuke/go-graylog/client/v8"
 )
 
 func testDeleteRole(

--- a/terraform/graylog/resource_stream.go
+++ b/terraform/graylog/resource_stream.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 )
 
 func resourceStream() *schema.Resource {

--- a/terraform/graylog/resource_stream_rule.go
+++ b/terraform/graylog/resource_stream_rule.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/schema"
 
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 )
 
 func resourceStreamRule() *schema.Resource {

--- a/terraform/graylog/resource_stream_rule_test.go
+++ b/terraform/graylog/resource_stream_rule_test.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"github.com/suzuki-shunsuke/go-graylog/client"
-	"github.com/suzuki-shunsuke/go-graylog/testutil"
+	"github.com/suzuki-shunsuke/go-graylog/client/v8"
+	"github.com/suzuki-shunsuke/go-graylog/testutil/v8"
 	"github.com/suzuki-shunsuke/graylog-mock-server/mockserver"
 )
 

--- a/terraform/graylog/resource_stream_test.go
+++ b/terraform/graylog/resource_stream_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/gofrs/uuid"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"github.com/suzuki-shunsuke/go-graylog/client"
-	"github.com/suzuki-shunsuke/go-graylog/testutil"
+	"github.com/suzuki-shunsuke/go-graylog/client/v8"
+	"github.com/suzuki-shunsuke/go-graylog/testutil/v8"
 	"github.com/suzuki-shunsuke/graylog-mock-server/mockserver"
 )
 

--- a/terraform/graylog/resource_user.go
+++ b/terraform/graylog/resource_user.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/suzuki-shunsuke/go-set"
 
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 )
 
 func resourceUser() *schema.Resource {

--- a/terraform/graylog/resource_user_test.go
+++ b/terraform/graylog/resource_user_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 
-	"github.com/suzuki-shunsuke/go-graylog/client"
+	"github.com/suzuki-shunsuke/go-graylog/client/v8"
 )
 
 func testDeleteUser(

--- a/terraform/graylog/util.go
+++ b/terraform/graylog/util.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 
-	"github.com/suzuki-shunsuke/go-graylog/client"
+	"github.com/suzuki-shunsuke/go-graylog/client/v8"
 	"github.com/suzuki-shunsuke/graylog-mock-server/mockserver"
 )
 

--- a/terraform/main.go
+++ b/terraform/main.go
@@ -4,7 +4,7 @@ import (
 	"github.com/hashicorp/terraform/plugin"
 	"github.com/hashicorp/terraform/terraform"
 
-	"github.com/suzuki-shunsuke/go-graylog/terraform/graylog"
+	"github.com/suzuki-shunsuke/go-graylog/terraform/graylog/v8"
 )
 
 func main() {

--- a/testdata/dashboard.go
+++ b/testdata/dashboard.go
@@ -3,7 +3,7 @@ package testdata
 import (
 	"github.com/suzuki-shunsuke/go-ptr"
 
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 )
 
 var (

--- a/testdata/dashboards.go
+++ b/testdata/dashboards.go
@@ -3,7 +3,7 @@ package testdata
 import (
 	"github.com/suzuki-shunsuke/go-ptr"
 
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 )
 
 var (

--- a/testdata/email_stream_alarm_callback.go
+++ b/testdata/email_stream_alarm_callback.go
@@ -3,7 +3,7 @@ package testdata
 import (
 	"github.com/suzuki-shunsuke/go-set"
 
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 )
 
 var (

--- a/testdata/http_stream_alarm_callback.go
+++ b/testdata/http_stream_alarm_callback.go
@@ -1,7 +1,7 @@
 package testdata
 
 import (
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 )
 
 var (

--- a/testdata/index_set.go
+++ b/testdata/index_set.go
@@ -1,7 +1,7 @@
 package testdata
 
 import (
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 )
 
 var (

--- a/testdata/index_sets.go
+++ b/testdata/index_sets.go
@@ -1,7 +1,7 @@
 package testdata
 
 import (
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 )
 
 var (

--- a/testdata/input.go
+++ b/testdata/input.go
@@ -1,7 +1,7 @@
 package testdata
 
 import (
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 )
 
 var (

--- a/testdata/inputs.go
+++ b/testdata/inputs.go
@@ -1,7 +1,7 @@
 package testdata
 
 import (
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 )
 
 var (

--- a/testdata/role.go
+++ b/testdata/role.go
@@ -3,7 +3,7 @@ package testdata
 import (
 	"github.com/suzuki-shunsuke/go-set"
 
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 )
 
 var (

--- a/testdata/roles.go
+++ b/testdata/roles.go
@@ -3,7 +3,7 @@ package testdata
 import (
 	"github.com/suzuki-shunsuke/go-set"
 
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 )
 
 var (

--- a/testdata/slack_stream_alarm_callback.go
+++ b/testdata/slack_stream_alarm_callback.go
@@ -1,7 +1,7 @@
 package testdata
 
 import (
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 )
 
 var (

--- a/testdata/stream.go
+++ b/testdata/stream.go
@@ -1,7 +1,7 @@
 package testdata
 
 import (
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 )
 
 var (

--- a/testdata/stream_alarm_callbacks.go
+++ b/testdata/stream_alarm_callbacks.go
@@ -3,7 +3,7 @@ package testdata
 import (
 	"github.com/suzuki-shunsuke/go-set"
 
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 )
 
 var (

--- a/testdata/stream_alert_conditions.go
+++ b/testdata/stream_alert_conditions.go
@@ -1,7 +1,7 @@
 package testdata
 
 import (
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 )
 
 var (

--- a/testdata/stream_rule.go
+++ b/testdata/stream_rule.go
@@ -1,7 +1,7 @@
 package testdata
 
 import (
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 )
 
 var (

--- a/testdata/stream_rules.go
+++ b/testdata/stream_rules.go
@@ -1,7 +1,7 @@
 package testdata
 
 import (
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 )
 
 var (

--- a/testdata/streams.go
+++ b/testdata/streams.go
@@ -1,7 +1,7 @@
 package testdata
 
 import (
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 )
 
 var (

--- a/testdata/user.go
+++ b/testdata/user.go
@@ -3,7 +3,7 @@ package testdata
 import (
 	"github.com/suzuki-shunsuke/go-set"
 
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 )
 
 var (

--- a/testdata/users.go
+++ b/testdata/users.go
@@ -3,7 +3,7 @@ package testdata
 import (
 	"github.com/suzuki-shunsuke/go-set"
 
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 )
 
 var (

--- a/testutil/test_data.go
+++ b/testutil/test_data.go
@@ -1,7 +1,7 @@
 package testutil
 
 import (
-	"github.com/suzuki-shunsuke/go-graylog"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
 	"github.com/suzuki-shunsuke/go-ptr"
 	"github.com/suzuki-shunsuke/go-set"
 )

--- a/testutil/test_data_test.go
+++ b/testutil/test_data_test.go
@@ -3,7 +3,7 @@ package testutil_test
 import (
 	"testing"
 
-	"github.com/suzuki-shunsuke/go-graylog/testutil"
+	"github.com/suzuki-shunsuke/go-graylog/testutil/v8"
 )
 
 func TestRole(t *testing.T) {

--- a/testutil/util.go
+++ b/testutil/util.go
@@ -7,8 +7,8 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"github.com/suzuki-shunsuke/go-graylog"
-	"github.com/suzuki-shunsuke/go-graylog/client"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
+	"github.com/suzuki-shunsuke/go-graylog/client/v8"
 	"github.com/suzuki-shunsuke/graylog-mock-server/mockserver"
 )
 

--- a/testutil/util_test.go
+++ b/testutil/util_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/suzuki-shunsuke/go-graylog/testutil"
+	"github.com/suzuki-shunsuke/go-graylog/testutil/v8"
 )
 
 func TestGetNonAdminUser(t *testing.T) {

--- a/user_test.go
+++ b/user_test.go
@@ -3,8 +3,8 @@ package graylog_test
 import (
 	"testing"
 
-	"github.com/suzuki-shunsuke/go-graylog"
-	"github.com/suzuki-shunsuke/go-graylog/testutil"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
+	"github.com/suzuki-shunsuke/go-graylog/testutil/v8"
 )
 
 func TestUserNewUpdateParams(t *testing.T) {

--- a/util/decode_test.go
+++ b/util/decode_test.go
@@ -3,8 +3,8 @@ package util_test
 import (
 	"testing"
 
-	"github.com/suzuki-shunsuke/go-graylog"
-	"github.com/suzuki-shunsuke/go-graylog/util"
+	"github.com/suzuki-shunsuke/go-graylog/v8"
+	"github.com/suzuki-shunsuke/go-graylog/util/v8"
 )
 
 func TestMSDecode(t *testing.T) {


### PR DESCRIPTION
issue: https://github.com/suzuki-shunsuke/go-graylog/issues/192

Add the suffix "/v8" to the import path by the following shell script.

```
while read -r path; do
  git ls-files | ag "\.go$" | xargs -n 1 sed -i "s!$path\"!$path/v8\"!"
done < <(go list ./...)
```

And update go.mod and go.sum.

This commit is still work in progress. The following errors occurs.

```
$ go vet ./...
build github.com/suzuki-shunsuke/go-graylog/v8/cmd/generate-testdata: cannot load github.com/suzuki-shunsuke/go-graylog/util/v8: module github.com/suzuki-shunsuke/go-graylog@latest found (v2.5.0+incompatible), but does not contain package github.com/suzuki-shunsuke/go-graylog/util/v8
```