### PR TITLE
fix: fix the parse error of Event Definition

### DIFF
--- a/terraform/docs/event_definition.md
+++ b/terraform/docs/event_definition.md
@@ -13,6 +13,7 @@ title | string |
 config | string | JSON string
 notifications[].notification_id | string |
 priority | int | 1 (Low), 2 (Normal), 3 (High)
+notification_settings | {} |
 
 `config` is a JSON string.
 The format of `config` depends on the Event Notification type.

--- a/terraform/example/v0.12/event_definition.tf
+++ b/terraform/example/v0.12/event_definition.tf
@@ -41,3 +41,44 @@ EOF
     notification_id = graylog_event_notification.http.id
   }
 }
+
+# https://github.com/suzuki-shunsuke/go-graylog/issues/170#issuecomment-564817360
+# https://www.terraform.io/docs/providers/random/r/uuid.html
+resource "random_uuid" "event_definition_test2_series0" {}
+
+resource "graylog_event_definition" "test2" {
+  title = "new-event-definition 2"
+  priority = 2
+  config = <<EOF
+{
+  "type": "aggregation-v1",
+  "query": "test",
+  "streams": [
+    "${graylog_stream.test.id}"
+  ],
+  "search_within_ms": 60000,
+  "execute_every_ms": 60000,
+  "group_by": [],
+  "series": [
+    {
+      "id": "${random_uuid.event_definition_test2_series0.result}",
+      "function": "count",
+      "field": null
+    }
+  ],
+  "conditions": {
+    "expression": {
+      "expr": ">",
+      "left": {
+        "expr": "number-ref",
+        "ref": "${random_uuid.event_definition_test2_series0.result}"
+      },
+      "right": {
+        "expr": "number",
+        "value": 0
+      }
+    }
+  }
+}
+EOF
+}

--- a/terraform/example/v0.12/event_definition.tf
+++ b/terraform/example/v0.12/event_definition.tf
@@ -81,4 +81,9 @@ resource "graylog_event_definition" "test2" {
   }
 }
 EOF
+  
+  notification_settings {
+    grace_period_ms = 0
+    backlog_size = 0
+  }
 }

--- a/terraform/example/v0.12/event_definition.tf
+++ b/terraform/example/v0.12/event_definition.tf
@@ -58,12 +58,14 @@ resource "graylog_event_definition" "test2" {
   ],
   "search_within_ms": 60000,
   "execute_every_ms": 60000,
-  "group_by": [],
+  "group_by": [
+    "alert"
+  ],
   "series": [
     {
       "id": "${random_uuid.event_definition_test2_series0.result}",
-      "function": "count",
-      "field": null
+      "function": "avg",
+      "field": "alert"
     }
   ],
   "conditions": {

--- a/terraform/graylog/resource_event_definition.go
+++ b/terraform/graylog/resource_event_definition.go
@@ -189,7 +189,11 @@ func getDefinitionCfg(d *schema.ResourceData) (map[string]interface{}, error) {
 }
 
 func getDefinitionSettings(d *schema.ResourceData) graylog.EventDefinitionNotificationSettings {
-	settings := d.Get("notification_settings").([]interface{})[0].(map[string]interface{})
+	s := d.Get("notification_settings").([]interface{})
+	if len(s) == 0 {
+		return graylog.EventDefinitionNotificationSettings{}
+	}
+	settings := s[0].(map[string]interface{})
 	gracePeriodMS := 0
 	if a, ok := settings["grace_period_ms"]; ok {
 		gracePeriodMS = a.(int)

--- a/terraform/graylog/resource_event_definition.go
+++ b/terraform/graylog/resource_event_definition.go
@@ -32,13 +32,13 @@ func resourceEventDefinition() *schema.Resource {
 			"priority": {
 				Type:     schema.TypeInt,
 				Required: true,
-				ValidateFunc: func(v interface{}, k string) (s []string, es []error) {
+				ValidateFunc: wrapValidateFunc(func(v interface{}, k string) error {
 					priority := v.(int)
 					if priority < 1 || priority > 3 {
-						es = append(es, errors.New("'priority' should be either 1, 2, and 3"))
+						return errors.New("'priority' should be either 1, 2, and 3")
 					}
-					return
-				},
+					return nil
+				}),
 			},
 			"config": {
 				Type:             schema.TypeString,
@@ -77,7 +77,7 @@ func resourceEventDefinition() *schema.Resource {
 				Type:             schema.TypeString,
 				Optional:         true,
 				DiffSuppressFunc: schemaDiffSuppressJSONString,
-				ValidateFunc:     validateFuncEventDefinitionFieldSpec,
+				ValidateFunc:     wrapValidateFunc(validateFuncEventDefinitionFieldSpec),
 			},
 			"notifications": {
 				Type:     schema.TypeList,
@@ -104,16 +104,17 @@ func resourceEventDefinition() *schema.Resource {
 	}
 }
 
-func validateFuncEventDefinitionFieldSpec(v interface{}, k string) (s []string, es []error) {
+func validateFuncEventDefinitionFieldSpec(v interface{}, k string) error {
 	a := strings.TrimSpace(v.(string))
 	if len(a) == 0 {
-		return
+		return nil
 	}
 	spec := map[string]graylog.EventDefinitionFieldSpec{}
 	if err := json.Unmarshal([]byte(a), &spec); err != nil {
-		es = append(es, fmt.Errorf("failed to parse the 'field_spec'. 'field_spec' must be a JSON string: %w", err))
+		return fmt.Errorf(
+			"failed to parse the 'field_spec'. 'field_spec' must be a JSON string: %w", err)
 	}
-	return
+	return nil
 }
 
 func getFieldSpec(d *schema.ResourceData) (map[string]graylog.EventDefinitionFieldSpec, error) {

--- a/terraform/graylog/resource_event_definition.go
+++ b/terraform/graylog/resource_event_definition.go
@@ -76,6 +76,7 @@ func resourceEventDefinition() *schema.Resource {
 			"field_spec": {
 				Type:             schema.TypeString,
 				Optional:         true,
+				Default:          "{}",
 				DiffSuppressFunc: schemaDiffSuppressJSONString,
 				ValidateFunc:     wrapValidateFunc(validateFuncEventDefinitionFieldSpec),
 			},

--- a/terraform/graylog/resource_event_definition.go
+++ b/terraform/graylog/resource_event_definition.go
@@ -48,7 +48,7 @@ func resourceEventDefinition() *schema.Resource {
 			},
 			"notification_settings": {
 				Type:     schema.TypeList,
-				Optional: true,
+				Required: true,
 				MaxItems: 1,
 				MinItems: 1,
 				Elem: &schema.Resource{

--- a/terraform/graylog/resource_event_definition.go
+++ b/terraform/graylog/resource_event_definition.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/suzuki-shunsuke/go-jsoneq/jsoneq"
@@ -104,16 +105,24 @@ func resourceEventDefinition() *schema.Resource {
 }
 
 func validateFuncEventDefinitionFieldSpec(v interface{}, k string) (s []string, es []error) {
+	a := strings.TrimSpace(v.(string))
+	if len(a) == 0 {
+		return
+	}
 	spec := map[string]graylog.EventDefinitionFieldSpec{}
-	if err := json.Unmarshal([]byte(v.(string)), &spec); err != nil {
+	if err := json.Unmarshal([]byte(a), &spec); err != nil {
 		es = append(es, fmt.Errorf("failed to parse the 'field_spec'. 'field_spec' must be a JSON string: %w", err))
 	}
 	return
 }
 
 func getFieldSpec(d *schema.ResourceData) (map[string]graylog.EventDefinitionFieldSpec, error) {
+	s := strings.TrimSpace(d.Get("field_spec").(string))
+	if len(s) == 0 {
+		return nil, nil
+	}
 	spec := map[string]graylog.EventDefinitionFieldSpec{}
-	if err := json.Unmarshal([]byte(d.Get("field_spec").(string)), &spec); err != nil {
+	if err := json.Unmarshal([]byte(s), &spec); err != nil {
 		return nil, fmt.Errorf("failed to parse the 'field_spec'. 'field_spec' must be a JSON string: %w", err)
 	}
 	return spec, nil

--- a/terraform/graylog/resource_event_definition.go
+++ b/terraform/graylog/resource_event_definition.go
@@ -43,7 +43,7 @@ func resourceEventDefinition() *schema.Resource {
 			"config": {
 				Type:             schema.TypeString,
 				Required:         true,
-				DiffSuppressFunc: cfgSchemaDiffSuppress,
+				DiffSuppressFunc: schemaDiffSuppressJSONString,
 				ValidateFunc:     validateFuncEventDefinitionConfig,
 			},
 			"notification_settings": {
@@ -76,7 +76,7 @@ func resourceEventDefinition() *schema.Resource {
 			"field_spec": {
 				Type:             schema.TypeString,
 				Optional:         true,
-				DiffSuppressFunc: cfgSchemaDiffSuppress,
+				DiffSuppressFunc: schemaDiffSuppressJSONString,
 				ValidateFunc:     validateFuncEventDefinitionFieldSpec,
 			},
 			"notifications": {

--- a/terraform/graylog/resource_event_notification.go
+++ b/terraform/graylog/resource_event_notification.go
@@ -34,7 +34,7 @@ func resourceEventNotification() *schema.Resource {
 			"config": {
 				Type:             schema.TypeString,
 				Required:         true,
-				DiffSuppressFunc: cfgSchemaDiffSuppress,
+				DiffSuppressFunc: schemaDiffSuppressJSONString,
 			},
 		},
 	}

--- a/terraform/graylog/resource_output.go
+++ b/terraform/graylog/resource_output.go
@@ -34,18 +34,10 @@ func resourceOutput() *schema.Resource {
 			"configuration": {
 				Type:             schema.TypeString,
 				Required:         true,
-				DiffSuppressFunc: cfgSchemaDiffSuppress,
+				DiffSuppressFunc: schemaDiffSuppressJSONString,
 			},
 		},
 	}
-}
-
-func cfgSchemaDiffSuppress(k, oldV, newV string, d *schema.ResourceData) bool {
-	b, err := jsoneq.Equal([]byte(oldV), []byte(newV))
-	if err != nil {
-		return false
-	}
-	return b
 }
 
 func newOutput(d *schema.ResourceData) (*graylog.Output, error) {

--- a/terraform/graylog/util.go
+++ b/terraform/graylog/util.go
@@ -21,6 +21,15 @@ func schemaDiffSuppressJSONString(k, oldV, newV string, d *schema.ResourceData) 
 	return b
 }
 
+func wrapValidateFunc(f func(v interface{}, k string) error) schema.SchemaValidateFunc {
+	return func(v interface{}, k string) (s []string, es []error) {
+		if err := f(v, k); err != nil {
+			es = append(es, err)
+		}
+		return
+	}
+}
+
 func genImport(keys ...string) schema.StateFunc {
 	return func(d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
 		a := strings.Split(d.Id(), "/")

--- a/terraform/graylog/util.go
+++ b/terraform/graylog/util.go
@@ -7,10 +7,19 @@ import (
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
+	"github.com/suzuki-shunsuke/go-jsoneq/jsoneq"
 
 	"github.com/suzuki-shunsuke/go-graylog/v8/client"
 	"github.com/suzuki-shunsuke/graylog-mock-server/mockserver"
 )
+
+func schemaDiffSuppressJSONString(k, oldV, newV string, d *schema.ResourceData) bool {
+	b, err := jsoneq.Equal([]byte(oldV), []byte(newV))
+	if err != nil {
+		return false
+	}
+	return b
+}
 
 func genImport(keys ...string) schema.StateFunc {
 	return func(d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {


### PR DESCRIPTION
https://github.com/suzuki-shunsuke/go-graylog/issues/170

## Bug fixes

* When the `field_spec` isn't set, a parse error raises
* When the `notification_settings` isn't set, an error raises
* Make Event Definition's notification_settings required
* Set default value to Event Definition's field_spec

## Update examples

https://github.com/suzuki-shunsuke/go-graylog/pull/202/files#diff-4aed3af48787b6d57b3f02745aa9bad2

## Refactoring

* https://github.com/suzuki-shunsuke/go-graylog/pull/202/commits/e64e04df688b48ed1223f59e5d26563a54ca3dde
* https://github.com/suzuki-shunsuke/go-graylog/pull/202/commits/f3625428b91d252a5ccf77bf063d17ce69f8e0eb

