### PR TITLE
Support any type of dashboard widget by JSON string

### DIFF
--- a/dashboard_widget.go
+++ b/dashboard_widget.go
@@ -188,3 +188,7 @@ func (cfg *WidgetConfigUnknownType) Type() string {
 func (cfg *WidgetConfigUnknownType) UnmarshalJSON(b []byte) error {
 	return json.Unmarshal(b, &cfg.Fields)
 }
+
+func (cfg *WidgetConfigUnknownType) MarshalJSON() ([]byte, error) {
+	return json.Marshal(&cfg.Fields)
+}

--- a/dashboard_widget_test.go
+++ b/dashboard_widget_test.go
@@ -4,27 +4,31 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/suzuki-shunsuke/go-jsoneq/jsoneq"
 	"github.com/suzuki-shunsuke/go-ptr"
 )
 
 func TestWidget_MarshalJSON(t *testing.T) {
-	widget := &Widget{
-		Description: "Stream search result count",
-		Config: &WidgetConfigStreamSearchResultCount{
-			Timerange: &Timerange{
-				Type:  "relative",
-				Range: 300,
+	data := []struct {
+		title  string
+		widget *Widget
+		exp    string
+	}{
+		{
+			title: "stream search result count",
+			widget: &Widget{
+				Description: "Stream search result count",
+				Config: &WidgetConfigStreamSearchResultCount{
+					Timerange: &Timerange{
+						Type:  "relative",
+						Range: 300,
+					},
+					LowerIsBetter: true,
+					Trend:         true,
+					StreamID:      "000000000000000000000001",
+				},
+				CacheTime: ptr.PInt(10),
 			},
-			LowerIsBetter: true,
-			Trend:         true,
-			StreamID:      "000000000000000000000001",
-		},
-		CacheTime: ptr.PInt(10),
-	}
-	d, err := widget.MarshalJSON()
-	require.Nil(t, err)
-	b, err := jsoneq.Equal(d, []byte(`{
+			exp: `{
   "type": "STREAM_SEARCH_RESULT_COUNT",
   "description": "Stream search result count",
   "config": {
@@ -38,7 +42,61 @@ func TestWidget_MarshalJSON(t *testing.T) {
     "stream_id": "000000000000000000000001"
   },
   "cache_time": 10
-}`))
-	require.Nil(t, err)
-	require.True(t, b)
+}`,
+		},
+		{
+			title: "stacked chart",
+			widget: &Widget{
+				Description: "stacked chart",
+				Config: &WidgetConfigUnknownType{
+					T: "STACKED_CHART",
+					Fields: map[string]interface{}{
+						"interval": "hour",
+						"timerange": map[string]interface{}{
+							"type":  "relative",
+							"range": 86400,
+						},
+						"renderer":      "bar",
+						"interpolation": "linear",
+						"series": []map[string]interface{}{
+							{
+								"query":                "",
+								"field":                "AccessMask",
+								"statistical_function": "count",
+							},
+						},
+					},
+				},
+				CacheTime: ptr.PInt(10),
+			},
+			exp: `{
+  "type": "STACKED_CHART",
+  "description": "stacked chart",
+  "config": {
+    "interval": "hour",
+    "timerange": {
+      "type": "relative",
+      "range": 86400
+    },
+    "renderer": "bar",
+    "interpolation": "linear",
+    "series": [
+      {
+        "query": "",
+        "field": "AccessMask",
+        "statistical_function": "count"
+      }
+    ]
+  },
+  "cache_time": 10
+}`,
+		},
+	}
+	for _, d := range data {
+		t.Run(d.title, func(t *testing.T) {
+			w, err := d.widget.MarshalJSON()
+			require.Nil(t, err)
+			require.JSONEq(t, d.exp, string(w))
+		})
+	}
 }

--- a/terraform/docs/dashboard_widget.md
+++ b/terraform/docs/dashboard_widget.md
@@ -3,23 +3,6 @@
 * [Example](https://github.com/suzuki-shunsuke/go-graylog/blob/master/terraform/example/v0.12/dashboard.tf)
 * [Source code](https://github.com/suzuki-shunsuke/go-graylog/blob/master/terraform/graylog/resource_dashboard_widget.go)
 
-```hcl
-resource "graylog_dashboard_widget" "test" {
-  description = "Stream search result count"
-  dashboard_id = "5b6586000000000000000000"
-  type = "STREAM_SEARCH_RESULT_COUNT"
-  stream_search_result_count_configuration {
-    timerange {
-      type = "relative"
-      range = 300
-    }
-    stream_id = "5b3983000000000000000000"
-    query = ""
-  }
-  cache_time = 10
-}
-```
-
 ## Supported types
 
 * STREAM_SEARCH_RESULT_COUNT
@@ -29,11 +12,12 @@ resource "graylog_dashboard_widget" "test" {
 * FIELD_CHART
 * STATS_COUNT
 
-## Unsupported types
+## `json_configuration`
 
-* STACKED_CHART
-* SEARCH_RESULT_COUNT
-* etc
+From v10.0.0, the attribute `json_configuration` is added to support any type of dashboard widget.
+`json_configuration` should be JSON string.
+
+Please see the [Example](https://github.com/suzuki-shunsuke/go-graylog/blob/master/terraform/example/v0.12/dashboard.tf).
 
 ## Common required arguments
 

--- a/terraform/example/v0.12/dashboard.tf
+++ b/terraform/example/v0.12/dashboard.tf
@@ -64,3 +64,28 @@ resource "graylog_dashboard_widget_positions" "test" {
     width     = 2
   }
 }
+
+resource "graylog_dashboard_widget" "stacked_chart" {
+  description        = "stacked chart"
+  dashboard_id       = graylog_dashboard.test.id
+  type               = "STACKED_CHART"
+  cache_time         = 10
+  json_configuration = <<EOF
+{
+  "interval": "hour",
+  "timerange": {
+    "type": "relative",
+    "range": 86400
+  },
+  "renderer": "bar",
+  "interpolation": "linear",
+  "series": [
+    {
+      "query": "",
+      "field": "AccessMask",
+      "statistical_function": "count"
+    }
+  ]
+}
+EOF
+}


### PR DESCRIPTION
#227 

The field `json_configuration` is added to `graylog_dashboard_widget` to support any type of dashboard widget.
The value of `json_configuration` should be JSON string.

Please see the example.

```hcl
resource "graylog_dashboard_widget" "stacked_chart" {
  description = "stacked chart"
  dashboard_id = graylog_dashboard.test.id
  type         = "STACKED_CHART"
  cache_time = 10
  json_configuration = <<EOF
{
  "interval": "hour",
  "timerange": {
    "type": "relative",
    "range": 86400
  },
  "renderer": "bar",
  "interpolation": "linear",
  "series": [
    {
      "query": "",
      "field": "AccessMask",
      "statistical_function": "count"
    }
  ]
}
EOF
}
```