### PR TITLE
fix: set blank id when it is failed to get a dashboard

### DIFF
--- a/terraform/graylog/resource_dashboard_widget_positions.go
+++ b/terraform/graylog/resource_dashboard_widget_positions.go
@@ -100,9 +100,9 @@ func resourceDashboardWidgetPositionsRead(d *schema.ResourceData, m interface{})
 	if err != nil {
 		return err
 	}
-	db, _, err := cl.GetDashboard(ctx, d.Id())
+	db, ei, err := cl.GetDashboard(ctx, d.Id())
 	if err != nil {
-		return err
+		return handleGetResourceError(d, ei, err)
 	}
 	if err := setStrToRD(d, "dashboard_id", d.Id()); err != nil {
 		return err


### PR DESCRIPTION
https://github.com/suzuki-shunsuke/go-graylog/issues/230#issuecomment-575601988