### PR TITLE
Implement Generic() func on Client

### DIFF
--- a/graylog/client/endpoint/endpoint.go
+++ b/graylog/client/endpoint/endpoint.go
@@ -34,6 +34,7 @@ type Endpoints struct {
 	connectStreamsToPipeline string
 	connectPipelinesToStream string
 	apiVersion               string
+	root                     string
 }
 
 // NewEndpoints returns a new Endpoints.
@@ -97,5 +98,6 @@ func newEndpoints(endpoint, version string) (*Endpoints, error) {
 		grokPatterns:             endpoint + "/system/grok",
 		grokPatternsTest:         endpoint + "/system/grok/test",
 		apiVersion:               version,
+		root:                     endpoint,
 	}, nil
 }

--- a/graylog/client/endpoint/generic.go
+++ b/graylog/client/endpoint/generic.go
@@ -1,0 +1,11 @@
+package endpoint
+
+import "strings"
+
+// Generic returns the URL of a generic endpoint without encoding
+func (ep *Endpoints) Generic(endpoint string) string {
+	// /{endpoint}
+
+	endpoint = strings.TrimLeft(endpoint, "/")
+	return ep.root + "/" + endpoint
+}

--- a/graylog/client/endpoint/generic_test.go
+++ b/graylog/client/endpoint/generic_test.go
@@ -1,0 +1,22 @@
+package endpoint_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/suzuki-shunsuke/go-graylog/v11/graylog/client/endpoint"
+)
+
+func TestEndpoints_Generic(t *testing.T) {
+	ep, err := endpoint.NewEndpoints(apiURL)
+	require.Nil(t, err)
+	require.Equal(t, fmt.Sprintf("%s/authz/shares", apiURL), ep.Generic("/authz/shares"))
+}
+
+func TestEndpoints_Generic2(t *testing.T) {
+	ep, err := endpoint.NewEndpoints(apiURL)
+	require.Nil(t, err)
+	require.Equal(t, fmt.Sprintf("%s/authz/shares", apiURL), ep.Generic("authz/shares"))
+}

--- a/graylog/client/generic.go
+++ b/graylog/client/generic.go
@@ -1,0 +1,13 @@
+package client
+
+import (
+	"context"
+)
+
+// Generic calls a generic API Endpoint by a relative endpoint URL
+func (client *Client) Generic(ctx context.Context, method, endpoint string, input, output interface{}) (
+	*ErrorInfo, error,
+) {
+	ei, err := client.callAPI(ctx, method, client.Endpoints().Generic(endpoint), input, output)
+	return ei, err
+}


### PR DESCRIPTION
This PR allows to call any API that is not (yet) implemented by the module itself, like "/authz/shares":

```golang
func shareStream(context context.Context, streamID string, userID string)  error
{
	request := struct {
		Selected_grantee_capabilities map[string]interface{} `json:"selected_grantee_capabilities"`
	}{map[string]interface{}{
		"grn::::user:" + userID: "view",
	}}

	grn := "grn::::stream:" + streamID
	_, err = client.Generic(ctx, http.MethodPost, "/authz/shares/entities/"+grn, request, nil)
	return err
}
```

To make my fork build successfully, I had to execute go mod tidy.
I did not commit the resulting changes to go.sum to avoid merge-conflicts.

I tried to keep the coding-style like the existing files.

I added unit-tests for the constructing the Endpoint URL, but no integration tests incl. Mock-Server.
Please let me know if you are interested in merging this PR, than I can implement these as well.

